### PR TITLE
Added browser + React Native support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { websocketClient } from "polygon.io";
 
 const stocksWS = websocketClient("api key").getStocksWebsocket();
 
-stocksWs.on("message", raw => {
+stocksWs.onmessage = raw => {
   const message = JSON.parse(raw);
   switch (message.ev) {
     case "T":

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,10 +148,10 @@
       "integrity": "sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==",
       "dev": true
     },
-    "@types/ws": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
-      "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+    "@types/websocket": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.0.tgz",
+      "integrity": "sha512-MLr8hDM8y7vvdAdnoDEP5LotRoYJj7wgT6mWzCUQH/gHqzS4qcnOT/K4dhC0WimWIUiA3Arj9QAJGGKNRiRZKA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -232,11 +232,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "backbone": {
       "version": "1.4.0",
@@ -508,6 +503,15 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -519,6 +523,15 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "date-fns": {
@@ -541,6 +554,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
       "version": "0.7.0",
@@ -656,6 +674,35 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -687,6 +734,21 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
       }
     },
     "fast-glob": {
@@ -1105,6 +1167,11 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "0.0.1",
@@ -1585,11 +1652,21 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -1619,6 +1696,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -1903,6 +1985,16 @@
         "once": "^1.3.1"
       }
     },
+    "query-string": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.10.1.tgz",
+      "integrity": "sha512-SHTUV6gDlgMXg/AQUuLpTiBtW/etZ9JT6k6RCtCyqADquApLX0Aq5oK/s5UeTUAWBG50IExjIr587GqfXRfM4A==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -2164,11 +2256,21 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.1",
@@ -2295,6 +2397,11 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -2306,6 +2413,14 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typedoc": {
       "version": "0.15.0",
@@ -2394,6 +2509,38 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "websocket": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
+      "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2469,19 +2616,16 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "ws": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
-    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.12",
     "@types/sinon": "^7.5.0",
-    "@types/ws": "^6.0.3",
+    "@types/websocket": "^1.0.0",
     "chai": "^4.2.0",
     "husky": "^3.0.9",
     "lint-staged": "^9.4.2",
@@ -52,6 +52,8 @@
     ]
   },
   "dependencies": {
-    "ws": "^7.1.2"
+    "cross-fetch": "^3.0.4",
+    "query-string": "^6.10.1",
+    "websocket": "^1.0.31"
   }
 }

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -1,8 +1,8 @@
-import * as https from "https";
-import * as querystring from "querystring";
+import fetch from "cross-fetch";
+import { stringify } from "query-string";
 
 export interface IPolygonQuery {
-  [key: string]: string | number | boolean;
+  [key: string]: string | number | boolean | undefined;
 }
 
 export interface IPolygonQueryWithCredentials extends IPolygonQuery {
@@ -11,42 +11,30 @@ export interface IPolygonQueryWithCredentials extends IPolygonQuery {
 
 export const auth = (apiKey, func) => (...args) => func(apiKey, ...args);
 
-export const get = (
+export const get = async (
   path: string,
   apiKey: string = "invalid",
   query?: IPolygonQuery
-): Promise<any> =>
-  new Promise((resolve, reject) => {
-    if (!apiKey) {
-      throw new Error("API KEY not configured...");
-    }
+): Promise<any> => {
+  if (!apiKey) {
+    throw new Error("API KEY not configured...");
+  }
 
-    const authenticatedQuery: IPolygonQueryWithCredentials = {
-      ...query,
-      apiKey
-    };
+  const authenticatedQuery: IPolygonQueryWithCredentials = {
+    ...query,
+    apiKey
+  };
 
-    const options = {
-      protocol: "https:",
-      method: "GET",
-      host: "api.polygon.io",
-      path: path + "?" + querystring.encode(authenticatedQuery)
-    };
+  const queryString = stringify(authenticatedQuery, { encode: true });
 
-    const request = https.request(options, (response: any) => {
-      let data = "";
-      response.on("data", function(chunk: string) {
-        data += chunk;
-      });
+  const url = `https://api.polygon.io${path}?${queryString}`;
 
-      response.on("end", function() {
-        resolve(JSON.parse(data));
-      });
-    });
+  const response = await fetch(url);
 
-    request.on("error", (error: any) => {
-      reject(error);
-    });
+  if (response.status >= 400) {
+    const message = await response.text();
+    throw new Error(message);
+  }
 
-    request.end();
-  });
+  return response.json();
+};

--- a/src/websockets/crypto/index.ts
+++ b/src/websockets/crypto/index.ts
@@ -1,5 +1,5 @@
 // Crypto QUOTE:
-import * as WebSocket from "ws";
+import { w3cwebsocket as Websocket } from "websocket";
 import { getWsClient } from "../transport";
 
 export interface IQuoteCryptoEvent {
@@ -70,5 +70,5 @@ export interface ILevel2CryptoEvent {
   r: number; // Tick Received @ Polygon Timestamp
 }
 
-export const getCryptoWebsocket = (apiKey: string): WebSocket =>
+export const getCryptoWebsocket = (apiKey: string): Websocket =>
   getWsClient("wss://socket.polygon.io/crypto", apiKey);

--- a/src/websockets/forex/index.ts
+++ b/src/websockets/forex/index.ts
@@ -1,6 +1,6 @@
 // Forex QUOTE:
 import { getWsClient } from "../transport";
-import * as WebSocket from "ws";
+import { w3cwebsocket as Websocket } from "websocket";
 
 export interface IQuoteForexEvent {
   ev: string; // Event Type
@@ -23,5 +23,5 @@ export interface IAggegateForexEvent {
   s: number; // Tick Start Timestamp
 }
 
-export const getForexWebsocket = (apiKey: string): WebSocket =>
+export const getForexWebsocket = (apiKey: string): Websocket =>
   getWsClient("wss://socket.polygon.io/forex", apiKey);

--- a/src/websockets/stocks/index.ts
+++ b/src/websockets/stocks/index.ts
@@ -1,6 +1,6 @@
 // Stocks TRADE:
 import { getWsClient } from "../transport";
-import * as WebSocket from "ws";
+import { w3cwebsocket as Websocket } from "websocket";
 
 export interface ITradeStockEvent {
   ev: string; // Event Type
@@ -45,5 +45,5 @@ export interface IAggregateStockEvent {
   e: number; // Tick End Timestamp ( Unix MS )
 }
 
-export const getStocksWebsocket = (apiKey: string): WebSocket =>
+export const getStocksWebsocket = (apiKey: string): Websocket =>
   getWsClient("wss://socket.polygon.io/stocks", apiKey);

--- a/src/websockets/transport/index.ts
+++ b/src/websockets/transport/index.ts
@@ -1,13 +1,15 @@
-import * as WebSocket from "ws";
+import { w3cwebsocket as Websocket } from "websocket";
 
-export const getWsClient = (url: string, apiKey: string): WebSocket => {
+export const getWsClient = (url: string, apiKey: string): Websocket => {
   if (!apiKey) {
     throw new Error("api key not provided.");
   }
-  const ws = new WebSocket(url);
-  ws.on("open", () => {
+
+  const ws = new Websocket(url);
+
+  ws.onopen = () => {
     ws.send(JSON.stringify({ action: "auth", params: apiKey }));
-  });
+  };
 
   return ws;
 };


### PR DESCRIPTION
This PR removes the dependency on several node-only modules in favor of cross-platform compatible alternatives. This will allow the library to be used in both browser and React Native environments. Specifically, this PR replaces the following modules:

|Old module|New module|
|------------|------------|
|`https` (node builtin)|[`cross-fetch`](https://www.npmjs.com/package/cross-fetch)|
|`ws`|[`websocket`](https://www.npmjs.com/package/websocket)\*|
|`querystring` (node builtin)|[`query-string`](https://www.npmjs.com/package/query-string)|

\* Note: Replacing `ws` with `websocket` introduces a breaking change which has been noted in the README.

Fixes #8 and #9.