### PR TITLE
Fix typings for rest tickers page results

### DIFF
--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -12,7 +12,15 @@ export interface ITickersQuery extends IPolygonQuery {
   active?: boolean;
 }
 
-export interface ITickers {
+export interface PageResult<T> {
+  page: number;
+  perPage: number;
+  count: number;
+  status: string;
+  tickers: T[]
+}
+
+export interface ITicker {
   ticker: string;
   name: string;
   market: string;
@@ -29,7 +37,7 @@ export interface ITickers {
 export const tickers = async (
   apiKey: string,
   query?: ITickersQuery
-): Promise<ITickers[]> => {
+): Promise<PageResult<ITicker>> => {
   const path: string = "/v2/reference/tickers";
   return get(path, apiKey, query);
 };


### PR DESCRIPTION
The typings for page results are incorrect, at least for tickers, probably the other ones too. You don't have to merge in this code, this is just an example of more or less what it should look like