### PR TITLE
Move baseApi Defaults and Rearrange Injected Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-# [polygon.io](https://polygon.io)
-
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-[![CircleCI](https://circleci.com/gh/bassochette/polygon.io.svg?style=svg)](https://circleci.com/gh/bassochette/polygon.io)
-
 ## Install
 
 ```bash
-npm install --save polygon.io
+npm install --save @polygon.io/client-js
 ```
 
 ## usage
@@ -16,7 +11,7 @@ npm install --save polygon.io
 - call the desired client with your api key to initialize it
 
 ```typescript
-import { polygonClient, restClient, websocketClient } from "polygon.io";
+import { polygonClient, restClient, websocketClient } from "@polygon.io/client-js";
 const rest = restClient("API KEY");
 
 // you can use the api now
@@ -32,7 +27,7 @@ rest.forex
 - import all the rest submodule
 
 ```typescript
-import { restClient } from "polygon.io";
+import { restClient } from "@polygon.io/client-js";
 
 const rest = restClient("api key");
 
@@ -42,7 +37,7 @@ rest.forex.previousClose().then(/* your success handler */);
 - import a specific submodule
 
 ```typescript
-import { referenceClient } from "polygon.io";
+import { referenceClient } from "@polygon.io/client-js";
 
 const reference = referenceClient("api key");
 
@@ -51,10 +46,10 @@ reference.tickers.then(/* your success handler */);
 
 ### [Websocket](https://polygon.io/sockets)
 
-You can get preauthenticated [websocket clients](https://www.npmjs.com/package/ws) for the 3 topics.
+You can get preauthenticated [websocket clients](https://www.npmjs.com/package/websocket) for the 3 topics.
 
 ```typescript
-import { websocketClient } from "polygon.io";
+import { websocketClient } from "@polygon.io/client-js";
 
 const stocksWS = websocketClient("api key").getStocksWebsocket();
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# [polygon.io](https://polygon.io)
+
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 ## Install
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "polygon.io",
-  "version": "2.0.2",
+  "name": "@polygon.io/client-js",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "polygon.io",
+  "name": "@polygon.io/client-js",
   "version": "2.1.0",
-  "description": "Node JS client for polygon.io api",
+  "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",
   "scripts": {
@@ -16,12 +16,19 @@
     "url": "git+https://github.com/polygon-io/client-js.git"
   },
   "keywords": [
-    "polygon.io"
+    "polygon.io",
+    "stock api",
+    "forex api",
+    "crypto api"
   ],
   "contributors": [
     {
       "name": "Julien Prugne",
       "email": "julien@webeleon.dev"
+    },
+    {
+      "name": "Katie Adams",
+      "email": "katie@polygon.io"
     }
   ],
   "license": "MIT",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ export interface IPolygonClient {
   websockets: IWebsocketClient;
 }
 
-export const polygonClient = (apiKey: string, restApiBase = "https://api.polygon.io", websocketApiBase = "wss://socket.polygon.io"): IPolygonClient => ({
+export const polygonClient = (apiKey: string, restApiBase?: string, websocketApiBase?: string): IPolygonClient => ({
   rest: restClient(apiKey, restApiBase),
   websockets: websocketClient(apiKey, websocketApiBase)
 });

--- a/src/rest/crypto/aggregates.ts
+++ b/src/rest/crypto/aggregates.ts
@@ -8,48 +8,48 @@ import {
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_aggs_ticker_ticker_prev
 export const cryptoPreviousClose = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
-    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, query, apiBase)
+    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, apiBase, query)
   );
 
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_aggs_ticker_ticker_range_multiplier_timespan_from_to
 export const cryptoAggregates = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
       apiKey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );
 
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_aggs_grouped_locale_locale_market_market_date
 export const cryptoGroupedDaily = async (
   apiKey: string,
+  apiBase: string,
   locale: string,
   market: string = "CRYPTO",
   date: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/grouped/locale/${locale}/market/${market}/${date}`,
       apiKey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );

--- a/src/rest/crypto/cryptoExchanges.ts
+++ b/src/rest/crypto/cryptoExchanges.ts
@@ -10,5 +10,5 @@ export interface ICryptoExchanges {
   url: string;
 }
 
-export const cryptoExchanges = (apiKey: string, apiBase?: string): Promise<ICryptoExchanges[]> =>
-  get(`/v1/meta/crypto-exchanges`, apiKey, undefined, apiBase);
+export const cryptoExchanges = (apiKey: string, apiBase: string): Promise<ICryptoExchanges[]> =>
+  get(`/v1/meta/crypto-exchanges`, apiKey, apiBase);

--- a/src/rest/crypto/dailyOpenClose.ts
+++ b/src/rest/crypto/dailyOpenClose.ts
@@ -8,15 +8,14 @@ import {
 // CF: https://polygon.io/docs/#!/Crypto/get_v1_open_close_crypto_from_to_date
 export const cryptoDailyOpenClose = async (
   apiKey: string,
+  apiBase: string,
   from: string,
   to: string,
-  date: string,
-  apiBase?: string
+  date: string
 ): Promise<ICryptoDailyOpenCloseFormatted> => {
   const raw: ICryptoDailyOpenCloseRaw = await get(
     `/v1/open-close/crypto/${from}/${to}/${date}`,
     apiKey,
-    undefined,
     apiBase
   );
   const data: ICryptoDailyOpenCloseFormatted = {

--- a/src/rest/crypto/historicCryptoTrades.ts
+++ b/src/rest/crypto/historicCryptoTrades.ts
@@ -41,17 +41,17 @@ export interface IHistoricCryptoTradeQuery extends IPolygonQuery {
 
 export const historicCryptoTrades = async (
   apiKey: string,
+  apiBase: string,
   from: string,
   to: string,
   date: string,
-  query: IHistoricCryptoTradeQuery = { limit: 100 },
-  apiBase?: string
+  query: IHistoricCryptoTradeQuery = { limit: 100 }
 ): Promise<IHistoricCryptoTradeFormatted> => {
   const raw: IHistoricCryptoTradeRaw = await get(
     `/v1/historic/crypto/${from}/${to}/${date}`,
     apiKey,
-    query,
-    apiBase
+    apiBase,
+    query
   );
   return {
     day: raw.day,

--- a/src/rest/crypto/index.ts
+++ b/src/rest/crypto/index.ts
@@ -88,7 +88,7 @@ export interface ICryptoClient {
   ) => Promise<IAggResponseFormatted>;
 }
 
-export const cryptoClient = (apiKey, apiBase?: string): ICryptoClient => ({
+export const cryptoClient = (apiKey, apiBase = "https://api.polygon.io"): ICryptoClient => ({
   dailyOpenClose: auth(apiKey, cryptoDailyOpenClose, apiBase),
   exchanges: auth(apiKey, cryptoExchanges, apiBase),
   lastTradeForPair: auth(apiKey, lastTradeForCryptoPair, apiBase),

--- a/src/rest/crypto/lastTradeForACryptoPair.ts
+++ b/src/rest/crypto/lastTradeForACryptoPair.ts
@@ -22,8 +22,8 @@ export interface ILastTradeForACryptoPair {
 
 export const lastTradeForCryptoPair = (
   apiKey: string,
+  apiBase: string,
   from: string,
-  to: string,
-  apiBase?: string
+  to: string
 ): Promise<ILastTradeForACryptoPair> =>
-  get(`/v1/last/crypto/${from}/${to}`, apiKey, undefined, apiBase);
+  get(`/v1/last/crypto/${from}/${to}`, apiKey, apiBase);

--- a/src/rest/crypto/snapshots.ts
+++ b/src/rest/crypto/snapshots.ts
@@ -88,12 +88,11 @@ export interface ICryptoSnapshotSingleTickerFormatted {
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_snapshot_locale_global_markets_crypto_tickers
 export const cryptoSnapshotAllTickers = async (
   apiKey: string,
-  apiBase?: string
+  apiBase: string
 ): Promise<ICryptoSnapshotAllTickersFormatted> => {
   const raw: ICryptoSnapshotAllTickersRaw = await get(
     `/v2/snapshot/locale/global/markets/crypto/tickers`,
     apiKey,
-    undefined,
     apiBase
   );
   return {
@@ -105,13 +104,12 @@ export const cryptoSnapshotAllTickers = async (
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_snapshot_locale_global_markets_crypto_tickers
 export const cryptoSnapshotSingleTicker = async (
   apiKey: string,
-  ticker: string,
-  apiBase?: string
+  apiBase: string,
+  ticker: string
 ): Promise<ICryptoSnapshotSingleTickerFormatted> => {
   const raw: ICryptoSnapshotSingleTickerRaw = await get(
     `/v2/snapshot/locale/global/markets/crypto/tickers/${ticker}`,
     apiKey,
-    undefined,
     apiBase
   );
   return {
@@ -123,13 +121,12 @@ export const cryptoSnapshotSingleTicker = async (
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_snapshot_locale_global_markets_crypto_direction
 export const cryptoSnapshotGainersLosers = async (
   apiKey: string,
-  direction: string = "gainers",
-  apiBase?: string
+  apiBase: string,
+  direction: string = "gainers"
 ): Promise<ICryptoSnapshotAllTickersFormatted> => {
   const raw: ICryptoSnapshotAllTickersRaw = await get(
     `/v2/snapshot/locale/global/markets/crypto/${direction}`,
     apiKey,
-    undefined,
     apiBase
   );
   return {
@@ -206,13 +203,12 @@ const formatICryptoSingleTickerFullBookRaw = (
 // CF: https://polygon.io/docs/#!/Crypto/get_v2_snapshot_locale_global_markets_crypto_tickers_ticker_book
 export const cryptoSnapshotSingleTickerFullBook = async (
   apiKey: string,
-  ticker: string,
-  apiBase?: string
+  apiBase: string,
+  ticker: string
 ): Promise<ICryptoSingleTickerFullBookFormatted> => {
   const raw: ICryptoSingleTickerFullBookRaw = await get(
     `/v2/snapshot/locale/global/markets/crypto/tickers/${ticker}/book`,
     apiKey,
-    undefined,
     apiBase
   );
   return formatICryptoSingleTickerFullBookRaw(raw);

--- a/src/rest/forex/aggregates.ts
+++ b/src/rest/forex/aggregates.ts
@@ -8,48 +8,48 @@ import {
 // CF: https://polygon.io/docs/#!/Forex--Currencies/get_v2_aggs_ticker_ticker_prev
 export const forexPreviousClose = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
-    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, query, apiBase)
+    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, apiBase, query)
   );
 
 // CF: https://polygon.io/docs/#!/Forex--Currencies/get_v2_aggs_ticker_ticker_range_multiplier_timespan_from_to
 export const forexAggregates = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
       apiKey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );
 
 // CF: https://polygon.io/docs/#!/Forex--Currencies/get_v2_aggs_grouped_locale_locale_market_market_date
 export const forexGroupedDaily = async (
   apiKey: string,
+  apiBase: string,
   locale: string,
   market: string = "FX",
   date: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/grouped/locale/${locale}/market/${market}/${date}`,
       apiKey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );

--- a/src/rest/forex/historicForexTicks.ts
+++ b/src/rest/forex/historicForexTicks.ts
@@ -60,12 +60,12 @@ export interface IHistoricForexTicksQuery extends IPolygonQuery {
 
 export const historicForexTicks = async (
   apiKey: string,
+  apiBase: string,
   from: string,
   to: string,
   date: string,
-  query: IHistoricForexTicksQuery,
-  apiBase?: string
+  query: IHistoricForexTicksQuery
 ): Promise<IHistoricForexTicksFormatted> =>
   formatIHistoricForexTicksRaw(
-    await get(`/v1/historic/forex/${from}/${to}/${date}`, apiKey, query, apiBase)
+    await get(`/v1/historic/forex/${from}/${to}/${date}`, apiKey, apiBase, query)
   );

--- a/src/rest/forex/index.ts
+++ b/src/rest/forex/index.ts
@@ -79,7 +79,7 @@ export interface IForexClient {
   ) => Promise<IForexSnapshotAllTickersResponseFormatted>;
 }
 
-export const forexClient = (apiKey: string, apiBase?: string): IForexClient => ({
+export const forexClient = (apiKey: string, apiBase = "https://api.polygon.io"): IForexClient => ({
   lastQuoteForCurrencyPair: auth(apiKey, lastQuoteForCurrencyPair, apiBase),
   historicTicks: auth(apiKey, historicForexTicks, apiBase),
   realTimeCurrencyConversion: auth(apiKey, realTimeCurrencyConversion, apiBase),

--- a/src/rest/forex/lastQuoteForCurrencyPair.ts
+++ b/src/rest/forex/lastQuoteForCurrencyPair.ts
@@ -16,8 +16,8 @@ export interface ILastQuoteForCurrencyPair {
 
 export const lastQuoteForCurrencyPair = (
   apiKey: string,
+  apiBase: string,
   from: string,
-  to: string,
-  apiBase?: string
+  to: string
 ): Promise<ILastQuoteForCurrencyPair> =>
-  get(`/v1/last_quote/currencies/${from}/${to}`, apiKey, undefined, apiBase);
+  get(`/v1/last_quote/currencies/${from}/${to}`, apiKey, apiBase);

--- a/src/rest/forex/realTimeCurrencyConversion.ts
+++ b/src/rest/forex/realTimeCurrencyConversion.ts
@@ -23,9 +23,9 @@ export interface IRealTimeConversion {
 
 export const realTimeCurrencyConversion = (
   apiKey: string,
+  apiBase: string,
   from: string,
   to: string,
-  query: IRealTimeConversionQuery,
-  apiBase?: string
+  query: IRealTimeConversionQuery
 ): Promise<IRealTimeConversion> =>
-  get(`/v1/conversion/${from}/${to}`, apiKey, query, apiBase);
+  get(`/v1/conversion/${from}/${to}`, apiKey, apiBase, query);

--- a/src/rest/forex/snapshots.ts
+++ b/src/rest/forex/snapshots.ts
@@ -82,18 +82,18 @@ const formatIForexSnapshotAllTickersResponseRaw = (
 // CF: https://polygon.io/docs/#!/Forex--Currencies/get_v2_snapshot_locale_global_markets_forex_tickers
 export const forexSnapshotAllTickers = async (
   apiKey: string,
-  apiBase?: string
+  apiBase: string
 ): Promise<IForexSnapshotAllTickersResponseFormatted> =>
   formatIForexSnapshotAllTickersResponseRaw(
-    await get(`/v2/snapshot/locale/global/markets/forex/tickers`, apiKey, undefined, apiBase)
+    await get(`/v2/snapshot/locale/global/markets/forex/tickers`, apiKey, apiBase)
   );
 
 // CF: https://polygon.io/docs/#!/Forex--Currencies/get_v2_snapshot_locale_global_markets_forex_direction
 export const forexSnapshotGainersLosers = async (
   apiKey: string,
-  direction: string = "gainers",
-  apiBase?: string
+  apiBase: string,
+  direction: string = "gainers"
 ): Promise<IForexSnapshotAllTickersResponseFormatted> =>
   formatIForexSnapshotAllTickersResponseRaw(
-    await get(`/v2/snapshot/locale/global/markets/forex/${direction}`, apiKey, undefined, apiBase)
+    await get(`/v2/snapshot/locale/global/markets/forex/${direction}`, apiKey, apiBase)
   );

--- a/src/rest/reference/index.ts
+++ b/src/rest/reference/index.ts
@@ -50,7 +50,7 @@ export interface IReferenceClient {
   tickerTypes: () => Promise<ITickerTypes>;
 }
 
-export const referenceClient = (apiKey: string, apiBase?: string): IReferenceClient => ({
+export const referenceClient = (apiKey: string, apiBase = "https://api.polygon.io"): IReferenceClient => ({
   locales: auth(apiKey, locales, apiBase),
   markets: auth(apiKey, markets, apiBase),
   marketHolydays: auth(apiKey, marketHolydays, apiBase),

--- a/src/rest/reference/locales.ts
+++ b/src/rest/reference/locales.ts
@@ -11,5 +11,5 @@ export interface ILocalesResponse {
   results?: ILocales[];
 }
 
-export const locales = async (apiKeys: string, apiBase?: string): Promise<ILocalesResponse> =>
-  get("/v2/reference/locales", apiKeys, undefined, apiBase);
+export const locales = async (apiKeys: string, apiBase: string): Promise<ILocalesResponse> =>
+  get("/v2/reference/locales", apiKeys, apiBase);

--- a/src/rest/reference/marketHolidays.ts
+++ b/src/rest/reference/marketHolidays.ts
@@ -12,5 +12,5 @@ export interface IMarketHolyday {
 
 export const marketHolydays = async (
   apiKey: string,
-  apiBase?: string
-): Promise<IMarketHolyday[]> => get("/v1/marketstatus/upcoming", apiKey, undefined, apiBase);
+  apiBase: string
+): Promise<IMarketHolyday[]> => get("/v1/marketstatus/upcoming", apiKey, apiBase);

--- a/src/rest/reference/marketStatus.ts
+++ b/src/rest/reference/marketStatus.ts
@@ -19,5 +19,5 @@ export interface IMarketStatus {
   };
 }
 
-export const marketStatus = async (apiKey: string, apiBase?: string): Promise<IMarketStatus> =>
-  get("/v1/marketstatus/now", apiKey, undefined, apiBase);
+export const marketStatus = async (apiKey: string, apiBase: string): Promise<IMarketStatus> =>
+  get("/v1/marketstatus/now", apiKey, apiBase);

--- a/src/rest/reference/markets.ts
+++ b/src/rest/reference/markets.ts
@@ -11,5 +11,5 @@ export interface IMarketResponse {
   results?: IMarket[];
 }
 
-export const markets = async (apiKey: string, apiBase?: string): Promise<IMarketResponse> =>
-  get("/v2/reference/markets", apiKey, undefined, apiBase);
+export const markets = async (apiKey: string, apiBase: string): Promise<IMarketResponse> =>
+  get("/v2/reference/markets", apiKey, apiBase);

--- a/src/rest/reference/stockDividends.ts
+++ b/src/rest/reference/stockDividends.ts
@@ -20,7 +20,7 @@ export interface IStockDividendsResults {
 
 export const stockDividends = async (
   apiKey: string,
-  symbol: string,
-  apiBase?: string
+  apiBase: string,
+  symbol: string
 ): Promise<IStockDividendsResults> =>
-  get(`/v2/reference/dividends/${symbol}`, apiKey, undefined, apiBase);
+  get(`/v2/reference/dividends/${symbol}`, apiKey, apiBase);

--- a/src/rest/reference/stockFinancials.ts
+++ b/src/rest/reference/stockFinancials.ts
@@ -128,8 +128,8 @@ export interface IStockFinancialResults {
 
 export const stockFinancials = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
-  query?: IStockFinancialQuery,
-  apiBase?: string
+  query?: IStockFinancialQuery
 ): Promise<IStockFinancialResults[]> =>
-  get(`/v2/reference/financials/${symbol}`, apiKey, query, apiBase);
+  get(`/v2/reference/financials/${symbol}`, apiKey, apiBase, query);

--- a/src/rest/reference/stockSplits.ts
+++ b/src/rest/reference/stockSplits.ts
@@ -19,7 +19,7 @@ export interface IStockSplitsResults {
 
 export const stockSplits = async (
   apiKey: string,
-  symbol: string,
-  apiBase?: string
+  apiBase: string,
+  symbol: string
 ): Promise<IStockSplitsResults> =>
-  get(`/v2/reference/splits/${symbol}`, apiKey, undefined, apiBase);
+  get(`/v2/reference/splits/${symbol}`, apiKey, apiBase);

--- a/src/rest/reference/tickerDetails.ts
+++ b/src/rest/reference/tickerDetails.ts
@@ -53,13 +53,12 @@ export interface ITickerDetailsFormatted {
 
 export const tickerDetails = async (
   apiKey: string,
-  symbol: string,
-  apiBase?: string
+  apiBase: string,
+  symbol: string
 ): Promise<ITickerDetailsFormatted> => {
   const raw: ITickerDetailsRaw = await get(
     `/v1/meta/symbols/${symbol}/company`,
     apiKey,
-    undefined,
     apiBase
   );
 

--- a/src/rest/reference/tickerNews.ts
+++ b/src/rest/reference/tickerNews.ts
@@ -18,8 +18,8 @@ export interface ITickerNews {
 
 export const tickerNews = (
   apiKey: string,
+  apiBase: string,
   symbol: string,
-  query?: ITickerNewsQuery,
-  apiBase?: string
+  query?: ITickerNewsQuery
 ): Promise<ITickerNews[]> =>
-  get(`/v1/meta/symbols/${symbol}/news`, apiKey, query, apiBase);
+  get(`/v1/meta/symbols/${symbol}/news`, apiKey, apiBase, query);

--- a/src/rest/reference/tickerTypes.ts
+++ b/src/rest/reference/tickerTypes.ts
@@ -6,5 +6,5 @@ export interface ITickerTypes {
   results?: any;
 }
 
-export const tickerTypes = async (apiKeys: string, apiBase?: string): Promise<ITickerTypes> =>
-  get("/v2/reference/types", apiKeys, undefined, apiBase);
+export const tickerTypes = async (apiKeys: string, apiBase: string): Promise<ITickerTypes> =>
+  get("/v2/reference/types", apiKeys, apiBase);

--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -28,9 +28,9 @@ export interface ITickers {
 
 export const tickers = async (
   apiKey: string,
-  query?: ITickersQuery,
-  apiBase?: string
+  apiBase: string,
+  query?: ITickersQuery
 ): Promise<ITickers[]> => {
   const path: string = "/v2/reference/tickers";
-  return get(path, apiKey, query, apiBase);
+  return get(path, apiKey, apiBase, query);
 };

--- a/src/rest/stocks/aggregates.ts
+++ b/src/rest/stocks/aggregates.ts
@@ -70,48 +70,48 @@ export interface IAggregateQuery extends IPolygonQuery {
 // CF : https://polygon.io/docs/#!/Stocks--Equities/get_v2_aggs_ticker_ticker_prev
 export const stocksPreviousClose = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
-    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, query, apiBase)
+    await get(`/v2/aggs/ticker/${ticker}/prev`, apiKey, apiBase, query)
   );
 
 // CF: https://polygon.io/docs/#!/Stocks--Equities/get_v2_aggs_ticker_ticker_range_multiplier_timespan_from_to
 export const stocksAggregates = async (
   apikey: string,
+  apiBase: string,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
       apikey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );
 
 // CF: https://polygon.io/docs/#!/Stocks--Equities/get_v2_aggs_grouped_locale_locale_market_market_date
 export const stocksGroupedDaily = async (
   apiKey: string,
+  apiBase: string,
   locale: string,
   market: string,
   date: string,
-  query?: IAggregateQuery,
-  apiBase?: string
+  query?: IAggregateQuery
 ): Promise<IAggResponseFormatted> =>
   formatIAggResponseRaw(
     await get(
       `/v2/aggs/grouped/locale/${locale}/market/${market}/${date}`,
       apiKey,
-      query,
-      apiBase
+      apiBase,
+      query
     )
   );

--- a/src/rest/stocks/conditionMappings.ts
+++ b/src/rest/stocks/conditionMappings.ts
@@ -7,7 +7,7 @@ export interface IConditionMappings {
 
 export const conditionMappings = async (
   apiKeys: string,
-  ticktype: string = "trades",
-  apiBase?: string
+  apiBase: string,
+  ticktype: string = "trades"
 ): Promise<IConditionMappings> =>
-  get(`/v1/meta/conditions/${ticktype}`, apiKeys, undefined, apiBase);
+  get(`/v1/meta/conditions/${ticktype}`, apiKeys, apiBase);

--- a/src/rest/stocks/dailyOpenClose.ts
+++ b/src/rest/stocks/dailyOpenClose.ts
@@ -21,7 +21,7 @@ export interface IDailyOpenClose {
 
 export const dailyOpenClose = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
-  date: string,
-  apiBase?: string
-): Promise<IDailyOpenClose> => get(`/v1/open-close/${symbol}/${date}`, apiKey, undefined, apiBase);
+  date: string
+): Promise<IDailyOpenClose> => get(`/v1/open-close/${symbol}/${date}`, apiKey, apiBase);

--- a/src/rest/stocks/exchanges.ts
+++ b/src/rest/stocks/exchanges.ts
@@ -25,6 +25,6 @@ const formatIExchangeRaw = (raw: IExchangeRaw): IExchangeFormatted => ({
 
 export const exchanges = async (
   apiKey: string,
-  apiBase?: string
+  apiBase: string
 ): Promise<IExchangeFormatted[]> =>
-  (await get(`/v1/meta/exchanges`, apiKey, undefined, apiBase)).map(formatIExchangeRaw);
+  (await get(`/v1/meta/exchanges`, apiKey, apiBase)).map(formatIExchangeRaw);

--- a/src/rest/stocks/index.ts
+++ b/src/rest/stocks/index.ts
@@ -121,7 +121,7 @@ export interface IStocksClient {
   ) => Promise<IAggResponseFormatted>;
 }
 
-export const stocksClient = (apiKey: string, apiBase?: string): IStocksClient => ({
+export const stocksClient = (apiKey: string, apiBase = "https://api.polygon.io"): IStocksClient => ({
   conditionMappings: auth(apiKey, conditionMappings, apiBase),
   dailyOpenClose: auth(apiKey, dailyOpenClose, apiBase),
   exchanges: auth(apiKey, exchanges, apiBase),

--- a/src/rest/stocks/lastQuoteForSymbol.ts
+++ b/src/rest/stocks/lastQuoteForSymbol.ts
@@ -18,6 +18,6 @@ export interface ILastQuoteResult {
 
 export const lastQuoteForSymbol = (
   apiKey: string,
-  symbol: string,
-  apiBase?: string
-): Promise<ILastQuoteResult> => get(`/v1/last_quote/stocks/${symbol}`, apiKey, undefined, apiBase);
+  apiBase: string,
+  symbol: string
+): Promise<ILastQuoteResult> => get(`/v1/last_quote/stocks/${symbol}`, apiKey, apiBase);

--- a/src/rest/stocks/lastTradeForSymbol.ts
+++ b/src/rest/stocks/lastTradeForSymbol.ts
@@ -21,6 +21,6 @@ export interface ILastTradeResult {
 
 export const lastTradeForSymbol = (
   apiKey: string,
-  symbol: string,
-  apiBase?: string
-): Promise<ILastTradeResult> => get(`/v1/last/stocks/${symbol}`, apiKey, undefined, apiBase);
+  apiBase: string,
+  symbol: string
+): Promise<ILastTradeResult> => get(`/v1/last/stocks/${symbol}`, apiKey, apiBase);

--- a/src/rest/stocks/snapshots.ts
+++ b/src/rest/stocks/snapshots.ts
@@ -116,10 +116,10 @@ const formatISnapshotAllTickersResultRaw = (
 
 export const snapshotAllTickers = async (
   apiKey: string,
-  apiBase?: string
+  apiBase: string
 ): Promise<ISnapshotAllTickersResultFormatted> =>
   formatISnapshotAllTickersResultRaw(
-    await get(`/v2/snapshot/locale/us/markets/stocks/tickers`, apiKey, undefined, apiBase)
+    await get(`/v2/snapshot/locale/us/markets/stocks/tickers`, apiKey, apiBase)
   );
 
 // CF: https://polygon.io/docs/#!/Stocks--Equities/get_v2_snapshot_locale_us_markets_stocks_tickers_ticker
@@ -140,11 +140,11 @@ const formatISnapshotSingleTickerResultRaw = (
 
 export const snapshotSingleTicker = async (
   apiKey: string,
+  apiBase: string,
   ticker: string,
-  apiBase?: string
 ): Promise<ISnapshotSingleTickerResultFormatted> =>
   formatISnapshotSingleTickerResultRaw(
-    await get(`/v2/snapshot/locale/us/markets/stocks/tickers/${ticker}`, apiKey, undefined, apiBase)
+    await get(`/v2/snapshot/locale/us/markets/stocks/tickers/${ticker}`, apiKey, apiBase)
   );
 
 // CF: https://polygon.io/docs/#!/Stocks--Equities/get_v2_snapshot_locale_us_markets_stocks_tickers_ticker
@@ -158,9 +158,9 @@ export interface ISnapshotGainersLosersResultFormatted {
 }
 export const snapshotGainersLosers = async (
   apiKey: string,
-  direction: string = "gainers",
-  apiBase?: string
+  apiBase: string,
+  direction: string = "gainers"
 ): Promise<ISnapshotGainersLosersResultFormatted> =>
   formatISnapshotAllTickersResultRaw(
-    await get(`/v2/snapshot/locale/us/markets/stocks/${direction}`, apiKey, undefined, apiBase)
+    await get(`/v2/snapshot/locale/us/markets/stocks/${direction}`, apiKey, apiBase)
   );

--- a/src/rest/stocks/v1HistoricQuotes.ts
+++ b/src/rest/stocks/v1HistoricQuotes.ts
@@ -88,11 +88,11 @@ export const formatIV1HistoricQuotesResultRaw = (
 
 export const v1HistoricQuotes = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
   date: string,
-  query?: IV1HistoricQuotesQuery,
-  apiBase?: string
+  query?: IV1HistoricQuotesQuery
 ): Promise<IV1HistoricQuotesResultFormatted> =>
   formatIV1HistoricQuotesResultRaw(
-    await get(`/v1/historic/quotes/${symbol}/${date}`, apiKey, query, apiBase)
+    await get(`/v1/historic/quotes/${symbol}/${date}`, apiKey, apiBase, query)
   );

--- a/src/rest/stocks/v1HistoricTrades.ts
+++ b/src/rest/stocks/v1HistoricTrades.ts
@@ -88,11 +88,11 @@ export const formatIV1HistoricTradesResultRaw = (
 
 export const v1HistoricTrades = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
   date: string,
-  query?: IV1HistoricTradesQuery,
-  apiBase?: string
+  query?: IV1HistoricTradesQuery
 ): Promise<IV1HistoricTradesResultFormatted> =>
   formatIV1HistoricTradesResultRaw(
-    await get(`/v1/historic/trades/${symbol}/${date}`, apiKey, query, apiBase)
+    await get(`/v1/historic/trades/${symbol}/${date}`, apiKey, apiBase, query)
   );

--- a/src/rest/stocks/v2HistoricQuotes.ts
+++ b/src/rest/stocks/v2HistoricQuotes.ts
@@ -95,11 +95,11 @@ const formatIV2HistoricQuotesResultRaw = (
 
 export const v2HistoricQuotes = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
   date: string,
-  query?: IV2HistoricQuotesQuery,
-  apiBase?: string
+  query?: IV2HistoricQuotesQuery
 ): Promise<IV2HistoricQuotesResultFormatted> =>
   formatIV2HistoricQuotesResultRaw(
-    await get(`/v2/ticks/stocks/nbbo/${symbol}/${date}`, apiKey, query, apiBase)
+    await get(`/v2/ticks/stocks/nbbo/${symbol}/${date}`, apiKey, apiBase, query)
   );

--- a/src/rest/stocks/v2HistoricTrades.ts
+++ b/src/rest/stocks/v2HistoricTrades.ts
@@ -82,11 +82,11 @@ export const formatIV2HistoricTradeResultRaw = (
 
 export const v2HistoricTrades = async (
   apiKey: string,
+  apiBase: string,
   symbol: string,
   date: string,
-  query?: IV2HistoricTradesQuery,
-  apiBase?: string
+  query?: IV2HistoricTradesQuery
 ): Promise<IV2HistoricTradesResultFormatted> =>
   formatIV2HistoricTradeResultRaw(
-    await get(`/v2/ticks/stocks/trades/${symbol}/${date}`, apiKey, query, apiBase)
+    await get(`/v2/ticks/stocks/trades/${symbol}/${date}`, apiKey, apiBase, query)
   );

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -9,13 +9,13 @@ export interface IPolygonQueryWithCredentials extends IPolygonQuery {
   apiKey: string | boolean;
 }
 
-export const auth = (apiKey, func: Function, apiBase: string) => (...args) => func(apiKey, ...args, apiBase);
+export const auth = (apiKey, func: Function, apiBase: string) => (...args) => func(apiKey, apiBase, ...args);
 
 export const get = async (
   path: string,
   apiKey: string = "invalid",
-  query?: IPolygonQuery,
-  apiBase?: string
+  apiBase: string,
+  query?: IPolygonQuery
 ): Promise<any> => {
   if (!apiKey) {
     throw new Error("API KEY not configured...");

--- a/src/websockets/crypto/index.ts
+++ b/src/websockets/crypto/index.ts
@@ -70,5 +70,5 @@ export interface ILevel2CryptoEvent {
   r: number; // Tick Received @ Polygon Timestamp
 }
 
-export const getCryptoWebsocket = (apiKey: string, apiBase?: string): Websocket =>
+export const getCryptoWebsocket = (apiKey: string, apiBase =  "wss://socket.polygon.io"): Websocket =>
   getWsClient(`${apiBase}/crypto`, apiKey);

--- a/src/websockets/forex/index.ts
+++ b/src/websockets/forex/index.ts
@@ -23,5 +23,5 @@ export interface IAggegateForexEvent {
   s: number; // Tick Start Timestamp
 }
 
-export const getForexWebsocket = (apiKey: string, apiBase?: string): Websocket =>
+export const getForexWebsocket = (apiKey: string, apiBase =  "wss://socket.polygon.io"): Websocket =>
   getWsClient(`${apiBase}/forex`, apiKey);

--- a/src/websockets/stocks/index.ts
+++ b/src/websockets/stocks/index.ts
@@ -46,5 +46,5 @@ export interface IAggregateStockEvent {
   e: number; // Tick End Timestamp ( Unix MS )
 }
 
-export const getStocksWebsocket = (apiKey: string, apiBase?: string): Websocket =>
+export const getStocksWebsocket = (apiKey: string, apiBase =  "wss://socket.polygon.io"): Websocket =>
   getWsClient(`${apiBase}/stocks`, apiKey);


### PR DESCRIPTION
Moved the defaults for baseAPI to each client so that they will apply to all possible entrypoints
Rearranged the injected parameters so that undefined optional parameters in existing code won't change