### PR TITLE
Update the API version for the tickers endpoint

### DIFF
--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -31,6 +31,6 @@ export const tickers = async (
   apiBase: string,
   query?: ITickersQuery
 ): Promise<ITickers[]> => {
-  const path: string = "/v2/reference/tickers";
+  const path: string = "/v3/reference/tickers";
   return get(path, apiKey, apiBase, query);
 };


### PR DESCRIPTION
Polygon.io has now fully deprecated their v2 endpoint so this should be updated to match what is currently available.