### PR TITLE
Upgrades stock's LastTrade and LastQuote to v2 endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -69,13 +69,13 @@ describe("[REST] Stock / equities", () => {
   it("lastTradeForSymbol call /v1/last/stocks/{symbol}", async () => {
     await stocks.lastTradeForSymbol("AAPL");
     requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/last/stocks/AAPL");
+    requestStub.getCalls()[0].args[0].should.eql("/v2/last/trade/AAPL");
   });
 
   it("lastQuoteForSymbol call /v1/last_quote/stocks/{symbol}", async () => {
     await stocks.lastQuoteForSymbol("AAPL");
     requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/last_quote/stocks/AAPL");
+    requestStub.getCalls()[0].args[0].should.eql("/v2/last/nbbo/AAPL");
   });
 
   it("dailyOpenClose call /v1/open-close/{symbol}/{date}", async () => {

--- a/src/rest/stocks/lastQuoteForSymbol.ts
+++ b/src/rest/stocks/lastQuoteForSymbol.ts
@@ -20,4 +20,4 @@ export const lastQuoteForSymbol = (
   apiKey: string,
   apiBase: string,
   symbol: string
-): Promise<ILastQuoteResult> => get(`/v1/last_quote/stocks/${symbol}`, apiKey, apiBase);
+): Promise<ILastQuoteResult> => get(`/v2/last/nbbo/${symbol}`, apiKey, apiBase);

--- a/src/rest/stocks/lastTradeForSymbol.ts
+++ b/src/rest/stocks/lastTradeForSymbol.ts
@@ -23,4 +23,4 @@ export const lastTradeForSymbol = (
   apiKey: string,
   apiBase: string,
   symbol: string
-): Promise<ILastTradeResult> => get(`/v1/last/stocks/${symbol}`, apiKey, apiBase);
+): Promise<ILastTradeResult> => get(`/v2/last/trade/${symbol}`, apiKey, apiBase);


### PR DESCRIPTION
Upgrades stock's LastTradeForSymbol and LastQuoteForSymbol to v2 endpoints.

Fixes issue https://github.com/polygon-io/client-js/issues/44

Note: This will be a major version bump given the breaking changes in the response. 