### PR TITLE
Fix tickerNews return type

### DIFF
--- a/src/rest/reference/index.ts
+++ b/src/rest/reference/index.ts
@@ -38,7 +38,7 @@ export interface IReferenceClient {
   stockDividends: (symbol: string) => Promise<IStockDividendsResults>;
   stockSplits: (symbol: string) => Promise<IStockSplitsResults>;
   tickerDetails: (symbol: string) => Promise<ITickerDetails>;
-  tickerNews: (query?: ITickerNewsQuery) => Promise<ITickerNews[]>;
+  tickerNews: (query?: ITickerNewsQuery) => Promise<ITickerNews>;
   tickers: (query?: ITickersQuery) => Promise<ITickers>;
   tickerTypes: (query?: ITickerTypesQuery) => Promise<ITickerTypes>;
 }


### PR DESCRIPTION
According to the documentation, as well as testing the return value, the return type of `tickerNews` should be an object with an array of `results`, not an array itself. The `TickerNews` shape is correct.

https://polygon.io/docs/stocks/get_v2_reference_news