### PR TITLE
Change return type for ITradeInfo in lastQuote.ts

### DIFF
--- a/src/rest/stocks/lastQuote.ts
+++ b/src/rest/stocks/lastQuote.ts
@@ -6,7 +6,7 @@ import { ITradeInfo } from "./trades";
 export interface ILastQuote {
   request_id?: string;
   status?: string;
-  results?: ITradeInfo[];
+  results?: ITradeInfo;
 }
 
 export const lastQuote = async (


### PR DESCRIPTION
### File : client-js/src/rest/stocks/lastQuote.ts

**The return type of property "results" of the Interface "ILastQuote" should not be an array according to the documentation.**

```
export interface ILastQuote {
  request_id?: string;
  status?: string;
  results?: ITradeInfo[]; // => results?: ITradeInfo ;
}
```
