### PR TITLE
Correct erroneously added type option for map-like query structures 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@polygon.io/client-js",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "workspaces": [
         "./lib/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/src/rest/reference/dividends.ts
+++ b/src/rest/reference/dividends.ts
@@ -21,55 +21,37 @@ export interface IDividendsResults {
 }
 
 export interface IDividendsQuery extends IPolygonQuery {
-  ticker?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  ex_dividend_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  record_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  declaration_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  pay_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  ticker?: string;
+  "ticker.lt"?: string;
+  "ticker.lte"?: string;
+  "ticker.gt"?: string;
+  "ticker.gte"?: string;
+  ex_dividend_date?: string;
+  "ex_dividend_date.lt"?: string;
+  "ex_dividend_date.lte"?: string;
+  "ex_dividend_date.gt"?: string;
+  "ex_dividend_date.gte"?: string;
+  record_date?: string;
+  "record_date.lt"?: string;
+  "record_date.lte"?: string;
+  "record_date.gt"?: string;
+  "record_date.gte"?: string;
+  declaration_date?: string;
+  "declaration_date.lt"?: string;
+  "declaration_date.lte"?: string;
+  "declaration_date.gt"?: string;
+  "declaration_date.gte"?: string;
+  pay_date?: string;
+  "pay_date.lt"?: string;
+  "pay_date.lte"?: string;
+  "pay_date.gt"?: string;
+  "pay_date.gte"?: string;
   frequency?: 0 | 1 | 2 | 4 | 12;
-  cash_amount?:
-    | number
-    | {
-        lt?: number;
-        lte?: number;
-        gt?: number;
-        gte?: number;
-      };
+	cash_amount?: string;
+  "cash_amount.lt"?: string;
+  "cash_amount.lte"?: string;
+  "cash_amount.gt"?: string;
+  "cash_amount.gte"?: string;
   dividend_type?: "CD" | "SC" | "LT" | "ST";
   order?: "asc" | "desc";
   limit?: number;

--- a/src/rest/reference/marketHolidays.ts
+++ b/src/rest/reference/marketHolidays.ts
@@ -7,7 +7,7 @@ export interface IMarketHoliday {
   date?: string;
   name?: string;
   open?: string;
-  staus?: string;
+  status?: string;
 }
 
 export const marketHolidays = async (

--- a/src/rest/reference/marketHolidays.ts
+++ b/src/rest/reference/marketHolidays.ts
@@ -5,6 +5,7 @@ import { get } from "../transport/request";
 export interface IMarketHoliday {
   close?: string;
   date?: string;
+	exchange?: string;
   name?: string;
   open?: string;
   status?: string;

--- a/src/rest/reference/optionsContracts.ts
+++ b/src/rest/reference/optionsContracts.ts
@@ -6,14 +6,11 @@ export interface IOptionsContractsQuery extends IPolygonQuery {
   ticker?: string;
   underlying_ticker?: string;
   contract_type?: string;
-  expiration_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  expiration_date?: string;
+  "expiration_date.lt"?: string;
+  "expiration_date.lte"?: string;
+  "expiration_date.gt"?: string;
+  "expiration_date.gte"?: string;
   order?: "asc" | "desc";
   limit?: number;
   sort?: string;

--- a/src/rest/reference/stockFinancials.ts
+++ b/src/rest/reference/stockFinancials.ts
@@ -40,40 +40,28 @@ export interface IStockFinancialResults {
 }
 
 export interface IStockFinancialQuery extends IPolygonQuery {
-  ticker?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  ticker?: string;
+  "ticker.lt"?: string;
+  "ticker.lte"?: string;
+  "ticker.gt"?: string;
+  "ticker.gte"?: string;
   cik?: string;
-  company_name?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  company_name?: string;
+  "company_name.lt"?: string;
+  "company_name.lte"?: string;
+  "company_name.gt"?: string;
+  "company_name.gte"?: string;
   sic?: string;
-  filling_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  period_of_report_date?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  filling_date?: string;
+  "filling_date.lt"?: string;
+  "filling_date.lte"?: string;
+  "filling_date.gt"?: string;
+  "filling_date.gte"?: string;
+  period_of_report_date?: string;
+  "period_of_report_date.lt"?: string;
+  "period_of_report_date.lte"?: string;
+  "period_of_report_date.gt"?: string;
+  "period_of_report_date.gte"?: string;
   timeframe?: "annual" | "quarterly";
   included_sources?: "true" | "false";
   order?: "asc" | "desc";

--- a/src/rest/reference/stockSplits.ts
+++ b/src/rest/reference/stockSplits.ts
@@ -17,22 +17,16 @@ export interface IStockSplitsResults {
 }
 
 export interface IStockSplitsQuery extends IPolygonQuery {
-  ticker?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
-  execution_data?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  ticker?: string;
+  "ticker.lt"?: string;
+  "ticker.lte"?: string;
+  "ticker.gt"?: string;
+  "ticker.gte"?: string;
+  execution_data?: string;
+  "execution_data.lt"?: string;
+  "execution_data.lte"?: string;
+  "execution_data.gt"?: string;
+  "execution_data.gte"?: string;
   reverse_split?: "true" | "false";
   order?: "asc" | "desc";
   limit?: number;

--- a/src/rest/reference/tickerNews.ts
+++ b/src/rest/reference/tickerNews.ts
@@ -11,14 +11,11 @@ export type Publisher = {
 };
 
 export interface ITickerNewsQuery extends IPolygonQuery {
-  ticker?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  ticker?: string;
+  "ticker.lt"?: string;
+  "ticker.lte"?: string;
+  "ticker.gt"?: string;
+  "ticker.gte"?: string;
   published_utc?: string;
   order?: Order;
   limit?: number;

--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -20,14 +20,11 @@ export type MarketType = "stocks" | "crypto" | "fx";
 export type Order = "asc" | "desc";
 
 export interface ITickersQuery extends IPolygonQuery {
-  ticker?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  ticker?: string;
+  "ticker.lt"?: string;
+  "ticker.lte"?: string;
+  "ticker.gt"?: string;
+  "ticker.gte"?: string;
   type?: TickerTypes;
   market?: MarketType;
   exchange?: string;

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -18,14 +18,11 @@ export interface ITradeInfo {
 }
 
 export interface ITradesQuotesQuery extends IPolygonQuery {
-  timestamp?:
-    | string
-    | {
-        lt?: string;
-        lte?: string;
-        gt?: string;
-        gte?: string;
-      };
+  timeframe?: string;
+  "timeframe.lt"?: string;
+  "timeframe.lte"?: string;
+  "timeframe.gt"?: string;
+  "timeframe.gte"?: string;
   order?: "asc" | "desc";
   limit?: number;
   sort?: "timestamp";

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -2,7 +2,7 @@ import fetch from "cross-fetch";
 import { stringify } from "query-string";
 
 export interface IPolygonQuery {
-  [key: string]: string | number | boolean | object | undefined;
+  [key: string]: string | number | boolean | undefined;
 }
 
 export interface IPolygonQueryWithCredentials extends IPolygonQuery {


### PR DESCRIPTION
- Remove the erroneously added `object` type option for the IPolygonQuery interface
- Update all interfaces with map-like type queries