### PR TITLE
Fixes incorrect payload attributes in ITradesQuotesQuery

### DIFF
--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -18,11 +18,11 @@ export interface ITradeInfo {
 }
 
 export interface ITradesQuotesQuery extends IPolygonQuery {
-  timeframe?: string;
-  "timeframe.lt"?: string;
-  "timeframe.lte"?: string;
-  "timeframe.gt"?: string;
-  "timeframe.gte"?: string;
+  timestamp?: string;
+  "timestamp.lt"?: string;
+  "timestamp.lte"?: string;
+  "timestamp.gt"?: string;
+  "timestamp.gte"?: string;
   order?: "asc" | "desc";
   limit?: number;
   sort?: "timestamp";


### PR DESCRIPTION
According to Trades documentation at https://polygon.io/docs/stocks/get_v3_trades__stockticker , the API supports query parameters starting _timestamp_, not _timestamp_.