### PR TITLE
Fixes incorrect payload attribute in ITrades

### DIFF
--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -18,11 +18,11 @@ export interface ITradeInfo {
 }
 
 export interface ITradesQuotesQuery extends IPolygonQuery {
-  timeframe?: string;
-  "timeframe.lt"?: string;
-  "timeframe.lte"?: string;
-  "timeframe.gt"?: string;
-  "timeframe.gte"?: string;
+  timestamp?: string;
+  "timestamp.lt"?: string;
+  "timestamp.lte"?: string;
+  "timestamp.gt"?: string;
+  "timestamp.gte"?: string;
   order?: "asc" | "desc";
   limit?: number;
   sort?: "timestamp";

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -32,7 +32,7 @@ export interface ITrades {
   next_url: string;
   request_id?: string;
   results?: ITradeInfo[];
-  success?: string;
+  status?: string;
 }
 
 export const trades = async (


### PR DESCRIPTION
According to https://polygon.io/docs/stocks/get_v3_trades__stockticker and according to responses coming from Polygon API, trades response returns parameter **status**, not **success**.