### PR TITLE
fix: correct 'results?' to expect object instead of object array

### DIFF
--- a/src/rest/reference/optionsContract.ts
+++ b/src/rest/reference/optionsContract.ts
@@ -28,7 +28,7 @@ export interface IOptionsContractResults {
 
 export interface IOptionsContract {
   request_id?: string;
-  results?: IOptionsContractResults[];
+  results?: IOptionsContractResults;
   status?: string;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update `results?` interface to expect an object instead of an object array. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Zenhub Ticket: [835](https://app.zenhub.com/workspaces/front-end-6041273131e20d0011cb88dc/issues/polygon-io/frontend/835)

[client-js GitHub issue](https://github.com/polygon-io/client-js/issues/95)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Customer pointed out inconsistency between our docs, and the code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compared against documentation. [Options Contract](https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker)

## Screenshots (if appropriate):
<img width="287" alt="image" src="https://user-images.githubusercontent.com/23112584/185236006-e77e9f5b-d118-4ff6-af5d-32f835596e85.png">