### PR TITLE
fix: add optional query params

### DIFF
--- a/src/rest/reference/index.ts
+++ b/src/rest/reference/index.ts
@@ -14,9 +14,9 @@ import {
   IOptionsContracts,
   optionsContracts,
 } from "./optionsContracts";
-import { IDividendsResults, stockDividends } from "./dividends";
-import { IStockSplitsResults, stockSplits } from "./stockSplits";
-import { IStockFinancialResults, stockFinancials } from "./stockFinancials";
+import { IDividendsResults, IDividendsQuery, stockDividends } from "./dividends";
+import { IStockSplitsResults, IStockSplitsQuery, stockSplits } from "./stockSplits";
+import { IStockFinancialResults, IStockFinancialQuery, stockFinancials } from "./stockFinancials";
 import { ITickerDetails, tickerDetails } from "./tickerDetails";
 import { ITickerNews, ITickerNewsQuery, tickerNews } from "./tickerNews";
 import { ITickers, ITickersQuery, tickers } from "./tickers";
@@ -46,9 +46,9 @@ export interface IReferenceClient {
   optionsContracts: (
     query?: IOptionsContractsQuery
   ) => Promise<IOptionsContracts>;
-  dividends: () => Promise<IDividendsResults>;
-  stockSplits: () => Promise<IStockSplitsResults>;
-  stockFinancials: () => Promise<IStockFinancialResults>;
+  dividends: (query?: IDividendsQuery) => Promise<IDividendsResults>;
+  stockSplits: (query?: IStockSplitsQuery) => Promise<IStockSplitsResults>;
+  stockFinancials: (query?: IStockFinancialQuery) => Promise<IStockFinancialResults>;
   tickerDetails: (symbol: string) => Promise<ITickerDetails>;
   tickerNews: (query?: ITickerNewsQuery) => Promise<ITickerNews>;
   tickers: (query?: ITickersQuery) => Promise<ITickers>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update `dividends`, `stockSplits`, and `stockFinancials` methods found on the `IReferenceClient` interface with optional query params.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Zenhub Ticket: [834](https://app.zenhub.com/workspaces/front-end-6041273131e20d0011cb88dc/issues/polygon-io/frontend/834)
GitHub user issue #96

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Addressing user GitHub issue.
