### PR TITLE
Fix crypto `SnapshotInfo` field name

### DIFF
--- a/src/rest/crypto/snapshots.ts
+++ b/src/rest/crypto/snapshots.ts
@@ -43,7 +43,7 @@ export interface SnapshotInfo {
   prevDay?: SnapshotPrevDay;
   ticker?: string;
   todaysChange?: number;
-  todayChangePerc?: number;
+  todaysChangePerc?: number;
   updated?: number;
 }
 


### PR DESCRIPTION
The interface `SnapshotInfo` currently defines a field `todayChangePerc` which I believe is a typo and should be `todaysChangePerc`.

https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers