### PR TITLE
Fixes incorrect payload attributes in ITradesQuotesQuery

### DIFF
--- a/src/rest/reference/stockSplits.ts
+++ b/src/rest/reference/stockSplits.ts
@@ -22,11 +22,11 @@ export interface IStockSplitsQuery extends IPolygonQuery {
   "ticker.lte"?: string;
   "ticker.gt"?: string;
   "ticker.gte"?: string;
-  execution_data?: string;
-  "execution_data.lt"?: string;
-  "execution_data.lte"?: string;
-  "execution_data.gt"?: string;
-  "execution_data.gte"?: string;
+  execution_date?: string;
+  "execution_date.lt"?: string;
+  "execution_date.lte"?: string;
+  "execution_date.gt"?: string;
+  "execution_date.gte"?: string;
   reverse_split?: "true" | "false";
   order?: "asc" | "desc";
   limit?: number;

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -18,11 +18,11 @@ export interface ITradeInfo {
 }
 
 export interface ITradesQuotesQuery extends IPolygonQuery {
-  timeframe?: string;
-  "timeframe.lt"?: string;
-  "timeframe.lte"?: string;
-  "timeframe.gt"?: string;
-  "timeframe.gte"?: string;
+  timestamp?: string;
+  "timestamp.lt"?: string;
+  "timestamp.lte"?: string;
+  "timestamp.gt"?: string;
+  "timestamp.gte"?: string;
   order?: "asc" | "desc";
   limit?: number;
   sort?: "timestamp";

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -32,7 +32,7 @@ export interface ITrades {
   next_url: string;
   request_id?: string;
   results?: ITradeInfo[];
-  success?: string;
+  status?: string;
 }
 
 export const trades = async (


### PR DESCRIPTION
According to documentation stock split queries accept `execution_date` instead of `execution_data`. This PR fixes the attribute naming.