### PR TITLE
fix: incorrect type spelling for summaries session value

### DIFF
--- a/src/rest/stocks/summaries.ts
+++ b/src/rest/stocks/summaries.ts
@@ -27,7 +27,7 @@ export interface ISession {
     late_trading_change_percent: number;
     low: number;
     open: number;
-    previous_close:  number;
+    previous_close: number;
     volume: number;
 
 }

--- a/src/rest/stocks/summaries.ts
+++ b/src/rest/stocks/summaries.ts
@@ -27,7 +27,7 @@ export interface ISession {
     late_trading_change_percent: number;
     low: number;
     open: number;
-    pervious_close: number;
+    previous_close:  number;
     volume: number;
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed type on `ISession` interface on the summaries endpoint.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#120](https://github.com/polygon-io/client-js/issues/120)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Requested change from launchpad user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through inbuilt testing suite to verify endpoints where being called correctly.