### PR TITLE
Add Request Configuration Options

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/mocharc",
+	"extension": ["ts"],
+	"node-option": ["experimental-specifier-resolution=node", "loader=ts-node/esm"],
+	"spec": ["src/**/*.test.ts"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+## [7.0.0](https://github.com/polygon-io/client-js/v6.2.0...v7.0.0) (2023-01-25)
+
+> Description
+
+### Upgrade Steps
+* [ACTION REQUIRED]
+
+### Node Version
+Version 7 exports ES Modules instead of CommonJS. To use this version in a Node project, you will need to use Node 16 or above.
+
+### Headers and Request Options
+The headers parameter has been replaced with a request options parameter which accepts headers. If you were passing headers to an endpoint, your code should change from
+
+```javascript
+rest.forex.previousClose("C:EURUSD", {}, myHeaders)
+```
+
+to
+
+```javascript
+rest.forex.previousClose("C:EURUSD", {}, { headers: myHeaders })
+```
+
+You can now pass request options other than headers in the same object. You can pass any of the [available request options for fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options) in the request options object.
+
+You can also pass request options when initializing the client like:
+
+```javascript
+const rest = restClient("API KEY", "https://api.polygon.io", { headers: myHeaders });
+```
+
+These will be applied to each request unless overridden by options passed directly to the endpoint.
+
+You can find more examples in the [configuration examples file](./examples/rest/configuration.js).
+
+### Breaking Changes
+* Node 16+ compilation target
+* Pass entire request options as optional parameter instead of just headers
+
+### New Features
+* Allow request options to be passed globally to the client, or individually to endpoint functions
+
+### Bug Fixes
+* Pass api key in header instead of query parameter to improve security
+
+### Other Changes
+* Improved test coverage
+* Additional examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,24 @@
 > Description
 
 ### Upgrade Steps
-* [ACTION REQUIRED]
 
-### Node Version
-Version 7 exports ES Modules instead of CommonJS. To use this version in a Node project, you will need to use Node 16 or above.
+#### Node Version
+To use this version in a node project you will need to use node 16 or above. This change was made to support exporting ES Modules instead of CommonJS Modules. The ES Modules exported by this package should be fully supported in Node 16+.
 
-### Headers and Request Options
+#### Headers and Request Options
 The headers parameter has been replaced with a request options parameter which accepts headers. If you were passing headers to an endpoint, your code should change from
 
 ```javascript
-rest.forex.previousClose("C:EURUSD", {}, myHeaders)
+rest.forex.previousClose("C:EURUSD", {}, myHeadersObject)
 ```
 
 to
 
 ```javascript
-rest.forex.previousClose("C:EURUSD", {}, { headers: myHeaders })
+rest.forex.previousClose("C:EURUSD", {}, { headers: myHeadersObject })
 ```
 
-You can now pass request options other than headers in the same object. You can pass any of the [available request options for fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options) in the request options object.
+This change was made to allow additional request options to be passed to the request. You can pass any of the [available request options for fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options) in the request options object, and they will be passed through to the fetch request.
 
 You can also pass request options when initializing the client like:
 
@@ -29,7 +28,7 @@ You can also pass request options when initializing the client like:
 const rest = restClient("API KEY", "https://api.polygon.io", { headers: myHeaders });
 ```
 
-These will be applied to each request unless overridden by options passed directly to the endpoint.
+These will be applied to each request unless overridden by options passed directly to the endpoint function.
 
 You can find more examples in the [configuration examples file](./examples/rest/configuration.js).
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ rest.forex
 
 ### [REST API](https://polygon.io/docs/stocks/getting-started)
 
-- import all the rest submodule
+- import the rest submodule
 
 ```typescript
 import { restClient } from "@polygon.io/client-js";
 
-const rest = restClient("api key");
+const rest = restClient("API KEY");
 
 rest.forex.previousClose("C:EURUSD").then(/* your success handler */);
 ```
@@ -43,10 +43,11 @@ rest.forex.previousClose("C:EURUSD").then(/* your success handler */);
 ```typescript
 import { referenceClient } from "@polygon.io/client-js";
 
-const reference = referenceClient("api key");
+const reference = referenceClient("API KEY");
 
 reference.tickers().then(/* your success handler */);
 ```
+
 
 #### [For Launchpad Examples and Usage, see Polygon Launchpad Examples](examples/rest/launchpad/README.md)
 
@@ -57,7 +58,7 @@ You can get preauthenticated [websocket clients](https://www.npmjs.com/package/w
 ```typescript
 import { websocketClient } from "@polygon.io/client-js";
 
-const stocksWS = websocketClient("api key").stocks();
+const stocksWS = websocketClient("API KEY").stocks();
 
 stocksWS.onmessage = ({data}) => {
   const [message] = JSON.parse(data);

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ import { referenceClient } from "@polygon.io/client-js";
 const reference = referenceClient("API KEY");
 
 reference.tickers().then(/* your success handler */);
+reference.conditions({ asset_class: 'stocks', data_type: 'trades', sort: 'id' }).then(/* your success handler */)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
+## Upgrading to Version 7
+
+See the [Release Notes](./CHANGELOG.md) for instructions on upgrading to Version 7.
+
 ## Install
 
 ```bash

--- a/examples/rest/configuration.js
+++ b/examples/rest/configuration.js
@@ -1,0 +1,24 @@
+const { restClient } = require('@polygon.io/client-js');
+
+// You can pass global options to fetch to add headers or configure requests
+const globalFetchOptions = {
+	method: 'HEAD'
+}
+const rest = restClient("API KEY", "https://api.polygon.io", globalFetchOptions);
+
+// You can also pass options to each individual call, each key will override keys from the options also set globally
+
+// The signal option configures a timeout of 8 seconds for this call.
+// The method option overrides the one we set globally.
+const controller = new AbortController();
+const id = setTimeout(() => controller.abort(), 8000);
+const overrideFetchOptions = {
+	method: 'GET',
+	signal: controller.signal
+};
+rest.forex.previousClose("C:EURUSD", {}, overrideFetchOptions).then((data) => {
+	clearTimeout(id);
+	console.log(data);
+}).catch(e => {
+	console.error('An error happened:', e.message);
+});

--- a/examples/rest/launchpad/README.md
+++ b/examples/rest/launchpad/README.md
@@ -18,9 +18,9 @@ const edgeHeaders = {
   'X-Polygon-Edge-User-Agent': useragent
 }
 
-const rest = restClient("api key", "https://api.polygon.io", edgeHeaders);
-rest.forex.previousClose("C:EURUSD").then(/* your success handler */);
+const rest = restClient("API KEY", "https://api.polygon.io");
+rest.forex.previousClose("C:EURUSD", {}, { headers: edgeHeaders }).then(/* your success handler */);
 
-const reference = referenceClient("api key", "https://api.polygon.io", edgeHeaders);
-reference.tickers().then(/* your success handler */);
+const reference = referenceClient("API KEY", "https://api.polygon.io");
+reference.tickers({}, { headers: edgeHeaders }).then(/* your success handler */);
 ```

--- a/examples/rest/launchpad/index.js
+++ b/examples/rest/launchpad/index.js
@@ -11,8 +11,8 @@ const edgeHeaders = {
   'X-Polygon-Edge-User-Agent': 'useragent'
 }
 
-const rest = restClient("api key", "https://api.polygon.io", edgeHeaders);
-rest.forex.previousClose("C:EURUSD").then(/* your success handler */);
+const rest = restClient("API KEY", "https://api.polygon.io");
+rest.forex.previousClose("C:EURUSD", {}, { headers: edgeHeaders }).then(/* your success handler */);
 
-const reference = referenceClient("api key", "https://api.polygon.io", edgeHeaders);
-reference.tickers().then(/* your success handler */);
+const reference = referenceClient("API KEY", "https://api.polygon.io");
+reference.tickers({}, { headers: edgeHeaders }).then(/* your success handler */);

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "ts-node": "^10.4.0",
         "typedoc": "^0.22.10",
         "typescript": "^4.5.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@polygon.io/client-js",
-      "version": "6.2.0",
+      "version": "7.0.0",
       "license": "MIT",
       "workspaces": [
         "./lib/*",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",
+  "type": "module",
   "scripts": {
-    "test": "mocha --require ts-node/register '**/*.test.ts'",
-    "test:watch": "mocha --require ts-node/register --watch '**/*.test.ts'",
+    "test": "mocha",
+    "test:watch": "mocha --watch",
     "format": "prettier --write '**/*.ts'",
     "build": "rm -rf ./lib && ./node_modules/.bin/tsc",
     "generate-doc": "typedoc src/main.ts"
@@ -76,5 +77,8 @@
   "workspaces": [
     "./lib/*",
     "./sandbox"
-  ]
+  ],
+  "engines": {
+    "node": ">=16"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha --require ts-node/register '**/*.test.ts'",
     "test:watch": "mocha --require ts-node/register --watch '**/*.test.ts'",
     "format": "prettier --write '**/*.ts'",
-    "build": "tsc",
+    "build": "rm -rf ./lib && ./node_modules/.bin/tsc",
     "generate-doc": "typedoc src/main.ts"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-export * from "./rest";
-export * from "./websockets";
+export * from "./rest/index.js";
+export * from "./websockets/index.js";
 
-import restClient, { IRestClient } from "./rest";
-import websocketClient, { IWebsocketClient } from "./websockets";
+import restClient, { IRestClient } from "./rest/index.js";
+import websocketClient, { IWebsocketClient } from "./websockets/index.js";
 
 export interface IPolygonClient {
   rest: IRestClient;

--- a/src/rest/crypto/aggregates.ts
+++ b/src/rest/crypto/aggregates.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoTicker__range__multiplier___timespan___from___to
 
-import { IGet, IRequestOptions } from "../transport/request";
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { IGet, IRequestOptions } from "../transport/request.js";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
 
 export const aggregates = async (
   get: IGet,

--- a/src/rest/crypto/aggregates.ts
+++ b/src/rest/crypto/aggregates.ts
@@ -1,23 +1,19 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoTicker__range__multiplier___timespan___from___to
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
 
 export const aggregates = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
   query?: IAggsQuery,
-  headers?: IHeaders,
+  options?: IRequestOptions,
 ): Promise<IAggs> =>
-  get(
-    `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
-    apikey,
-    apiBase,
+  get(`/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
     query,
-    headers
+    options
   );

--- a/src/rest/crypto/aggregatesGroupedDaily.ts
+++ b/src/rest/crypto/aggregatesGroupedDaily.ts
@@ -1,20 +1,19 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_grouped_locale_global_market_crypto__date
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,
 } from "../stocks/aggregatesGroupedDaily";
 
 export const aggregatesGroupedDaily = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   date: string,
-  query?: IAggsGroupedDailyQuery
+  query?: IAggsGroupedDailyQuery,
+  options?: IRequestOptions
 ): Promise<IAggsGroupedDaily> =>
   get(
     `/v2/aggs/grouped/locale/global/market/crypto/${date}`,
-    apiKey,
-    apiBase,
-    query
+    query,
+    options
   );

--- a/src/rest/crypto/aggregatesGroupedDaily.ts
+++ b/src/rest/crypto/aggregatesGroupedDaily.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_grouped_locale_global_market_crypto__date
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,

--- a/src/rest/crypto/dailyOpenClose.ts
+++ b/src/rest/crypto/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_open-close_crypto__from___to___date
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 import { ITick } from "./ITickJson";
 
 export interface ICryptoDailyOpenCloseQuery extends IPolygonQuery {

--- a/src/rest/crypto/dailyOpenClose.ts
+++ b/src/rest/crypto/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_open-close_crypto__from___to___date
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 import { ITick } from "./ITickJson";
 
 export interface ICryptoDailyOpenCloseQuery extends IPolygonQuery {
@@ -18,11 +18,11 @@ export interface ICryptoDailyOpenClose {
 }
 
 export const dailyOpenClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   from: string,
   to: string,
   date: string,
-  query?: ICryptoDailyOpenCloseQuery
+  query?: ICryptoDailyOpenCloseQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoDailyOpenClose> =>
-  get(`/v1/open-close/crypto/${from}/${to}/${date}`, apiKey, apiBase, query);
+  get(`/v1/open-close/crypto/${from}/${to}/${date}`, query, options);

--- a/src/rest/crypto/ema.ts
+++ b/src/rest/crypto/ema.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IEma } from '../stocks/ema';
 
 export const ema = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, query, options);

--- a/src/rest/crypto/ema.ts
+++ b/src/rest/crypto/ema.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IEma } from '../stocks/ema';
 

--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-import { cryptoClient, ICryptoClient } from "./index";
-import * as fetch from "cross-fetch";
+import { cryptoClient, ICryptoClient } from "./index.js";
+import fetchModule from '../transport/fetch';
 
 describe("[REST] Crypto", () => {
   chai.should();
@@ -25,7 +25,7 @@ describe("[REST] Crypto", () => {
   const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
   const setStub = (returnVal, status = 200) => {
     fetchStub?.restore();
-    fetchStub = sandbox.stub(fetch, "default").returns(
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
       Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
     );
     crypto = cryptoClient(mocks.key, mocks.base, mocks.globalOptions);

--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -1,178 +1,196 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-
-import * as request from "../transport/request";
-import { cryptoClient } from "./index";
+import { cryptoClient, ICryptoClient } from "./index";
+import * as fetch from "cross-fetch";
 
 describe("[REST] Crypto", () => {
   chai.should();
-  let requestStub;
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  let crypto: ICryptoClient;
   const sandbox = sinon.createSandbox();
-  const crypto = cryptoClient("invalid");
-  beforeEach(() => {
-    requestStub = sandbox.stub(request, "get").returns(Promise.resolve({}));
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetch, "default").returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+    crypto = cryptoClient(mocks.key, mocks.base, mocks.globalOptions);
+  }
+  beforeEach(async () => {
+    setStub({});
   });
   afterEach(() => {
     sandbox.restore();
   });
 
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await crypto.aggregates("BTC", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/BTC/range/1/day/2019-01-01/2019-02-01"
     );
-    await crypto.aggregates("BTC", 1, "day", "2019-01-01", "2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/ticker/BTC/range/1/day/2019-01-01/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("aggregates grouped daily call /v2/aggs/grouped/locale/global/market/market/{date}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await crypto.aggregatesGroupedDaily("2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/grouped/locale/global/market/crypto/2019-02-01"
     );
-    await crypto.aggregatesGroupedDaily("2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/grouped/locale/global/market/crypto/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("daily open close call /v1/open-close/crypto/{from}/{to}/{date}", async () => {
-    await crypto.dailyOpenClose("BTC", "USD", "2019-01-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v1/open-close/crypto/BTC/USD/2019-01-01");
+    await crypto.dailyOpenClose("BTC", "USD", "2019-01-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/open-close/crypto/BTC/USD/2019-01-01");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("previous close call /v2/aggs/ticker/{ticker}/prev", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
-    );
-    await crypto.previousClose("BTC");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/aggs/ticker/BTC/prev");
+    setStub({ results: [] });
+    await crypto.previousClose("BTC", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/aggs/ticker/BTC/prev");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("trades call /v3/trades/{cryptoTicker}", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        ticks: [],
-      })
-    );
-    await crypto.trades("X:BTC-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/trades/X:BTC-USD");
+    setStub({ ticks: [] });
+    await crypto.trades("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/trades/X:BTC-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("last trade call /v1/last/crypto/{from}/{to}", async () => {
-    await crypto.lastTrade("BTC", "ETH");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/last/crypto/BTC/ETH");
+    await crypto.lastTrade("BTC", "ETH", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/last/crypto/BTC/ETH");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - all tickers call /v2/snapshot/locale/global/markets/crypto/tickers", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        tickers: [],
-      })
-    );
-    await crypto.snapshotAllTickers();
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/global/markets/crypto/tickers");
+    setStub({ tickers: [] });
+    await crypto.snapshotAllTickers(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/global/markets/crypto/tickers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - gainers / losers call /v2/snapshot/locale/global/markets/crypto/{direction}", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        tickers: [],
-      })
-    );
-    await crypto.snapshotGainersLosers("gainers");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/global/markets/crypto/gainers");
+    setStub({ tickers: [] });
+    await crypto.snapshotGainersLosers("gainers", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/global/markets/crypto/gainers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - ticker call /v2/snapshot/locale/global/markets/crypto/tickers/{ticker}", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        status: "",
-        ticker: {
-          day: {},
-          lastTrade: {},
-          min: {},
-          prevDay: {},
-        },
-      })
+    setStub({
+      status: "",
+      ticker: {
+        day: {},
+        lastTrade: {},
+        min: {},
+        prevDay: {},
+      },
+    });
+    await crypto.snapshotTicker("X:BTCUSD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/snapshot/locale/global/markets/crypto/tickers/X:BTCUSD"
     );
-    await crypto.snapshotTicker("X:BTCUSD");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/snapshot/locale/global/markets/crypto/tickers/X:BTCUSD"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - full book l2 call /v2/snapshot/locale/global/markets/crypto/tickers/{ticker}/book", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        data: {},
-      })
+    setStub({ data: {} });
+    await crypto.snapshotTickerFullBookL2("BTCUSD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/snapshot/locale/global/markets/crypto/tickers/BTCUSD/book"
     );
-    await crypto.snapshotTickerFullBookL2("BTCUSD");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/snapshot/locale/global/markets/crypto/tickers/BTCUSD/book"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("sma call /v1/indicators/sma/{cryptoTicker}", async () => {
-    await crypto.sma("X:BTC-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/sma/X:BTC-USD");
+    await crypto.sma("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/sma/X:BTC-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ema call /v1/indicators/ema/{cryptoTicker}", async () => {
-    await crypto.ema("X:BTC-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/ema/X:BTC-USD");
+    await crypto.ema("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/ema/X:BTC-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("macd call /v1/indicators/macd/{cryptoTicker}", async () => {
-    await crypto.macd("X:BTC-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/macd/X:BTC-USD");
+    await crypto.macd("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/macd/X:BTC-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("rsi call /v1/indicators/rsi/{cryptoTicker}", async () => {
-    await crypto.rsi("X:BTC-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/rsi/X:BTC-USD");
+    await crypto.rsi("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/rsi/X:BTC-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("apiKey and apiBase are passed", async () => {
+    await crypto.rsi("X:BTC-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
+    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
   });
 });

--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -191,6 +191,20 @@ describe("[REST] Crypto", () => {
     await crypto.rsi("X:BTC-USD", mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
-    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].headers.Authorization.should.eql(`Bearer ${mocks.key}`);
+  });
+
+  it("global options are applied if query is not passed in", async () => {
+    await crypto.rsi("X:BTC-USD");
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.globalOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("all options are applied if query is undefined", async () => {
+    await crypto.rsi("X:BTC-USD", undefined, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 });

--- a/src/rest/crypto/index.ts
+++ b/src/rest/crypto/index.ts
@@ -1,4 +1,4 @@
-import { auth, IHeaders } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
 import {
@@ -64,64 +64,74 @@ export interface ICryptoClient {
     from: string,
     to: string,
     query?: IAggsQuery,
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IAggs>;
   aggregatesGroupedDaily: (
     date: string,
-    query?: IAggsGroupedDailyQuery
+    query?: IAggsGroupedDailyQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsGroupedDaily>;
-  summaries: (query?: ISummariesQuery, headers?: IHeaders) => Promise<ISummaries>;
+  summaries: (query?: ISummariesQuery, options?: IRequestOptions) => Promise<ISummaries>;
   dailyOpenClose: (
     from: string,
     to: string,
     date: string,
-    query?: ICryptoDailyOpenCloseQuery
+    query?: ICryptoDailyOpenCloseQuery,
+    options?: IRequestOptions
   ) => Promise<ICryptoDailyOpenClose>;
   trades: (
     cryptoTicker: string,
-    query?: ITradesQuotesQuery
+    query?: ITradesQuotesQuery,
+    options?: IRequestOptions
   ) => Promise<ICryptoTrade>;
-  lastTrade: (from: string, to: string) => Promise<ICryptoLastTrade>;
+  lastTrade: (from: string, to: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ICryptoLastTrade>;
   previousClose: (
     symbol: string,
-    query?: IAggsPreviousCloseQuery
+    query?: IAggsPreviousCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsPreviousClose>;
   snapshotAllTickers: (
-    query?: ICryptoSnapshotAllTickersQuery
+    query?: ICryptoSnapshotAllTickersQuery,
+    options?: IRequestOptions
   ) => Promise<ICryptoSnapshotTickers>;
   snapshotGainersLosers: (
-    direction: "gainers" | "losers"
+    direction: "gainers" | "losers",
+    query?: IPolygonQuery,
+    options?: IRequestOptions
   ) => Promise<ICryptoSnapshotTickers>;
-  snapshotTicker: (symbol: string) => Promise<ICryptoSnapshot>;
+  snapshotTicker: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ICryptoSnapshot>;
   snapshotTickerFullBookL2: (
-    symbol: string
+    symbol: string, query?: IPolygonQuery, options?: IRequestOptions
   ) => Promise<ICryptoSnapshotFullBookL2>;
-  sma: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<ISma>;
-  ema: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IEma>;
-  macd: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IMacd>;
-  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IRsi>;
+  sma: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<ISma>;
+  ema: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IEma>;
+  macd: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IMacd>;
+  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IRsi>;
 }
 
 export const cryptoClient = (
   apiKey,
   apiBase = "https://api.polygon.io",
-  headers?: IHeaders
-): ICryptoClient => ({
-  aggregates: auth(apiKey, aggregates, apiBase, headers),
-  aggregatesGroupedDaily: auth(apiKey, aggregatesGroupedDaily, apiBase),
-  summaries: auth(apiKey, summaries, apiBase, headers),
-  dailyOpenClose: auth(apiKey, dailyOpenClose, apiBase),
-  lastTrade: auth(apiKey, lastTrade, apiBase),
-  trades: auth(apiKey, trades, apiBase),
-  previousClose: auth(apiKey, previousClose, apiBase),
-  snapshotAllTickers: auth(apiKey, snapshotAllTickers, apiBase),
-  snapshotGainersLosers: auth(apiKey, snapshotGainersLosers, apiBase),
-  snapshotTicker: auth(apiKey, snapshotTicker, apiBase),
-  snapshotTickerFullBookL2: auth(apiKey, snapshotTickerFullBookL2, apiBase),
-  sma: auth(apiKey, sma, apiBase), 
-  ema: auth(apiKey, ema, apiBase), 
-  macd: auth(apiKey, macd, apiBase), 
-  rsi: auth(apiKey, rsi, apiBase)
-});
-
+  options?: IRequestOptions
+): ICryptoClient => {
+  const get = getWithGlobals(apiKey, apiBase, options)
+  
+  return ({
+    aggregates: (...args) => aggregates(get, ...args),
+    aggregatesGroupedDaily: (...args) => aggregatesGroupedDaily(get, ...args),
+    summaries: (...args) => summaries(get, ...args),
+    dailyOpenClose: (...args) => dailyOpenClose(get, ...args),
+    lastTrade: (...args) => lastTrade(get, ...args),
+    trades: (...args) => trades(get, ...args),
+    previousClose: (...args) => previousClose(get, ...args),
+    snapshotAllTickers: (...args) => snapshotAllTickers(get, ...args),
+    snapshotGainersLosers: (...args) => snapshotGainersLosers(get, ...args),
+    snapshotTicker: (...args) => snapshotTicker(get, ...args),
+    snapshotTickerFullBookL2: (...args) => snapshotTickerFullBookL2(get, ...args),
+    sma: (...args) => sma(get, ...args),
+    ema: (...args) => ema(get, ...args),
+    macd: (...args) => macd(get, ...args),
+    rsi: (...args) => rsi(get, ...args)
+  });
+}
 export default cryptoClient;

--- a/src/rest/crypto/index.ts
+++ b/src/rest/crypto/index.ts
@@ -1,25 +1,25 @@
-import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,
-} from "../stocks/aggregatesGroupedDaily";
+} from "../stocks/aggregatesGroupedDaily.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
-} from "../stocks/previousClose";
-import { ITradesQuotesQuery } from "../stocks/trades";
-import { aggregates } from "./aggregates";
-import { aggregatesGroupedDaily } from "./aggregatesGroupedDaily";
+} from "../stocks/previousClose.js";
+import { ITradesQuotesQuery } from "../stocks/trades.js";
+import { aggregates } from "./aggregates.js";
+import { aggregatesGroupedDaily } from "./aggregatesGroupedDaily.js";
 import {
   ICryptoDailyOpenCloseQuery,
   ICryptoDailyOpenClose,
   dailyOpenClose,
-} from "./dailyOpenClose";
-import { ICryptoTrade, trades } from "./trades";
-import { ICryptoLastTrade, lastTrade } from "./lastTrade";
-import { previousClose } from "./previousClose";
+} from "./dailyOpenClose.js";
+import { ICryptoTrade, trades } from "./trades.js";
+import { ICryptoLastTrade, lastTrade } from "./lastTrade.js";
+import { previousClose } from "./previousClose.js";
 import {
   ICryptoSnapshotAllTickersQuery,
   ICryptoSnapshotTickers,
@@ -29,14 +29,14 @@ import {
   snapshotGainersLosers,
   snapshotTicker,
   snapshotTickerFullBookL2,
-} from "./snapshots";
-import { ISummaries, ISummariesQuery } from "../stocks/summaries";
-import { summaries } from "./summaries";
-import { ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { ISma, sma } from "./sma";
-import { IEma, ema } from "./ema";
-import { IMacd, macd } from "./macd";
-import { IRsi, rsi } from "./rsi";
+} from "./snapshots.js";
+import { ISummaries, ISummariesQuery } from "../stocks/summaries.js";
+import { summaries } from "./summaries.js";
+import { ITechnicalIndicatorsQuery } from "../stocks/sma.js";
+import { ISma, sma } from "./sma.js";
+import { IEma, ema } from "./ema.js";
+import { IMacd, macd } from "./macd.js";
+import { IRsi, rsi } from "./rsi.js";
 
 export {
   ICryptoDailyOpenCloseQuery,

--- a/src/rest/crypto/lastTrade.ts
+++ b/src/rest/crypto/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_last_crypto__from___to
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface ICryptoLastTrade {
   status?: string;

--- a/src/rest/crypto/lastTrade.ts
+++ b/src/rest/crypto/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_last_crypto__from___to
 
-import { get } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface ICryptoLastTrade {
   status?: string;
@@ -16,9 +16,10 @@ export interface ICryptoLastTrade {
 }
 
 export const lastTrade = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   from: string,
-  to: string
+  to: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoLastTrade> =>
-  get(`/v1/last/crypto/${from}/${to}`, apiKey, apiBase);
+  get(`/v1/last/crypto/${from}/${to}`, query, options);

--- a/src/rest/crypto/macd.ts
+++ b/src/rest/crypto/macd.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IMacd } from '../stocks/macd';
 
 export const macd = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, query, options);

--- a/src/rest/crypto/macd.ts
+++ b/src/rest/crypto/macd.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IMacd } from '../stocks/macd';
 

--- a/src/rest/crypto/previousClose.ts
+++ b/src/rest/crypto/previousClose.ts
@@ -1,15 +1,15 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoTicker__prev
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
 } from "../stocks/previousClose";
 
 export const previousClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
-  query?: IAggsPreviousCloseQuery
+  query?: IAggsPreviousCloseQuery,
+  options?: IRequestOptions
 ): Promise<IAggsPreviousClose> =>
-  get(`/v2/aggs/ticker/${symbol}/prev`, apiKey, apiBase, query);
+  get(`/v2/aggs/ticker/${symbol}/prev`, query, options);

--- a/src/rest/crypto/previousClose.ts
+++ b/src/rest/crypto/previousClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoTicker__prev
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,

--- a/src/rest/crypto/rsi.ts
+++ b/src/rest/crypto/rsi.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IRsi } from '../stocks/rsi';
 

--- a/src/rest/crypto/rsi.ts
+++ b/src/rest/crypto/rsi.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IRsi } from '../stocks/rsi';
 
 export const rsi = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, query, options);

--- a/src/rest/crypto/sma.ts
+++ b/src/rest/crypto/sma.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/crypto/get_v1_indicators_sma__cryptoticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { ISma } from '../stocks/sma';
 

--- a/src/rest/crypto/sma.ts
+++ b/src/rest/crypto/sma.ts
@@ -1,13 +1,13 @@
 // CF: https://polygon.io/docs/crypto/get_v1_indicators_sma__cryptoticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { ISma } from '../stocks/sma';
 
 export const sma = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, query, options);

--- a/src/rest/crypto/snapshots.ts
+++ b/src/rest/crypto/snapshots.ts
@@ -1,4 +1,4 @@
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface SnapshotDay {
   c?: number;
@@ -84,49 +84,51 @@ export interface ICryptoSnapshotFullBookL2 {
 
 // CF: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers
 export const snapshotAllTickers = (
-  apiKey: string,
-  apiBase: string,
-  query?: ICryptoSnapshotAllTickersQuery
+  get: IGet,
+  query?: ICryptoSnapshotAllTickersQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoSnapshotTickers> =>
   get(
     `/v2/snapshot/locale/global/markets/crypto/tickers`,
-    apiKey,
-    apiBase,
-    query
+    query,
+    options
   );
 
 // CF: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto__direction
 export const snapshotGainersLosers = (
-  apiKey: string,
-  apiBase: string,
-  direction: "gainers" | "losers"
+  get: IGet,
+  direction: "gainers" | "losers",
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoSnapshotTickers> =>
   get(
     `/v2/snapshot/locale/global/markets/crypto/${direction}`,
-    apiKey,
-    apiBase
+    query,
+    options
   );
 
 // CF: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker
 export const snapshotTicker = (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoSnapshot> =>
   get(
     `/v2/snapshot/locale/global/markets/crypto/tickers/${symbol}`,
-    apiKey,
-    apiBase
+    query,
+    options
   );
 
 // CF: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker__book
 export const snapshotTickerFullBookL2 = (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoSnapshotFullBookL2> =>
   get(
     `/v2/snapshot/locale/global/markets/crypto/tickers/${symbol}/book`,
-    apiKey,
-    apiBase
+    query,
+    options
   );

--- a/src/rest/crypto/snapshots.ts
+++ b/src/rest/crypto/snapshots.ts
@@ -1,4 +1,4 @@
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface SnapshotDay {
   c?: number;

--- a/src/rest/crypto/summaries.ts
+++ b/src/rest/crypto/summaries.ts
@@ -1,18 +1,15 @@
 // CF: https://polygon.io/docs/crypto/launchpad/get_v1_summaries
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   query?: ISummariesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<ISummaries> =>
   get(
     `/v1/summaries`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/crypto/summaries.ts
+++ b/src/rest/crypto/summaries.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/launchpad/get_v1_summaries
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (

--- a/src/rest/crypto/trades.ts
+++ b/src/rest/crypto/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_historic_crypto__from___to___date
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface ICryptoTradeInfo {
@@ -20,9 +20,9 @@ export interface ICryptoTrade {
 }
 
 export const trades = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   cryptoTicker: string,
-  query?: ITradesQuotesQuery
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
 ): Promise<ICryptoTrade> =>
-  get(`/v3/trades/${cryptoTicker}`, apiKey, apiBase, query);
+  get(`/v3/trades/${cryptoTicker}`, query, options);

--- a/src/rest/crypto/trades.ts
+++ b/src/rest/crypto/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/crypto/get_v1_historic_crypto__from___to___date
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface ICryptoTradeInfo {

--- a/src/rest/forex/aggregates.ts
+++ b/src/rest/forex/aggregates.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_ticker__forexTicker__range__multiplier___timespan___from___to
 
-import { IGet, IRequestOptions } from "../transport/request";
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { IGet, IRequestOptions } from "../transport/request.js";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
 
 export const aggregates = async (
   get: IGet,

--- a/src/rest/forex/aggregates.ts
+++ b/src/rest/forex/aggregates.ts
@@ -1,23 +1,20 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_ticker__forexTicker__range__multiplier___timespan___from___to
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
 
 export const aggregates = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
   query?: IAggsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IAggs> =>
   get(
     `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/forex/aggregatesGroupedDaily.ts
+++ b/src/rest/forex/aggregatesGroupedDaily.ts
@@ -1,20 +1,19 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_grouped_locale_global_market_fx__date
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,
 } from "../stocks/aggregatesGroupedDaily";
 
 export const aggregatesGroupedDaily = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   date: string,
-  query?: IAggsGroupedDailyQuery
+  query?: IAggsGroupedDailyQuery,
+  options?: IRequestOptions
 ): Promise<IAggsGroupedDaily> =>
   get(
     `/v2/aggs/grouped/locale/global/market/forex/${date}`,
-    apiKey,
-    apiBase,
-    query
+    query,
+    options
   );

--- a/src/rest/forex/aggregatesGroupedDaily.ts
+++ b/src/rest/forex/aggregatesGroupedDaily.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_grouped_locale_global_market_fx__date
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,

--- a/src/rest/forex/conversion.ts
+++ b/src/rest/forex/conversion.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_conversion__from___to
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface IConversionQuery extends IPolygonQuery {
   amount?: number;

--- a/src/rest/forex/conversion.ts
+++ b/src/rest/forex/conversion.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_conversion__from___to
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface IConversionQuery extends IPolygonQuery {
   amount?: number;
@@ -21,10 +21,10 @@ export interface IConversion {
 }
 
 export const conversion = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   from: string,
   to: string,
-  query?: IConversionQuery
+  query?: IConversionQuery,
+  options?: IRequestOptions
 ): Promise<IConversion> =>
-  get(`/v1/conversion/${from}/${to}`, apiKey, apiBase, query);
+  get(`/v1/conversion/${from}/${to}`, query, options);

--- a/src/rest/forex/ema.ts
+++ b/src/rest/forex/ema.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IEma } from '../stocks/ema';
 
 export const ema = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, query, options);

--- a/src/rest/forex/ema.ts
+++ b/src/rest/forex/ema.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IEma } from '../stocks/ema';
 

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -1,162 +1,185 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-import * as request from "../transport/request";
 import { forexClient } from "./index";
+import * as fetch from "cross-fetch";
 
 describe("[REST] Forex / Currencies", () => {
   chai.should();
-  let requestStub;
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  let fx;
   const sandbox = sinon.createSandbox();
-  const fx = forexClient("fakeApiKey");
-  beforeEach(() => {
-    requestStub = sandbox.stub(request, "get").returns(Promise.resolve({}));
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetch, "default").returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+    fx = forexClient(mocks.key, mocks.base, mocks.globalOptions);
+  }
+  beforeEach(async () => {
+    setStub({});
   });
   afterEach(() => {
     sandbox.restore();
   });
 
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await fx.aggregates("EURCHF", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/EURCHF/range/1/day/2019-01-01/2019-02-01"
     );
-    await fx.aggregates("EURCHF", 1, "day", "2019-01-01", "2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/ticker/EURCHF/range/1/day/2019-01-01/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("aggregates grouped daily call /v2/aggs/grouped/locale/market/{date}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await fx.aggregatesGroupedDaily("2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/grouped/locale/global/market/forex/2019-02-01"
     );
-    await fx.aggregatesGroupedDaily("2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/grouped/locale/global/market/forex/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("previous close call /v2/aggs/ticker/{ticker}/prev", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
-    );
-    await fx.previousClose("EURCHF");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/aggs/ticker/EURCHF/prev");
+    setStub({ results: [] });
+    await fx.previousClose("EURCHF", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/aggs/ticker/EURCHF/prev");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("quotes call /v3/quotes/{fxTicker}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        ticks: [],
-      })
-    );
-    await fx.quotes("C:EUR-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/quotes/C:EUR-USD");
+    setStub({ ticks: [] });
+    await fx.quotes("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/quotes/C:EUR-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("last quote call /v1/last_quote/currencies/{from}/{to}", async () => {
-    await fx.lastQuote("USD", "AUD");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v1/last_quote/currencies/USD/AUD");
+    await fx.lastQuote("USD", "AUD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/last_quote/currencies/USD/AUD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("conversion call /v1/conversion/{from}/{to}", async () => {
-    await fx.conversion("AUD", "USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/conversion/AUD/USD");
+    await fx.conversion("AUD", "USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/conversion/AUD/USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - all tickers call /v2/snapshot/locale/global/markets/forex/tickers", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        tickers: [],
-      })
-    );
-    await fx.snapshotAllTickers();
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/global/markets/forex/tickers");
+    setStub({ tickers: [] });
+    await fx.snapshotAllTickers(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/global/markets/forex/tickers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - gainers / losers call /v2/snapshot/locale/global/markets/forex/{direction}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        tickers: [],
-      })
-    );
-    await fx.snapshotGainersLosers("gainers");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/global/markets/forex/gainers");
+    setStub({ tickers: [] });
+    await fx.snapshotGainersLosers("gainers", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/global/markets/forex/gainers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot ticker call /v2/snapshot/locale/global/markets/forex/tickers/{ticker}", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        ticker: {
-          day: {},
-          lastTrade: {},
-          lastQuote: {},
-          min: {},
-          prevDay: {},
-        },
-      })
+    setStub({
+      ticker: {
+        day: {},
+        lastTrade: {},
+        lastQuote: {},
+        min: {},
+        prevDay: {},
+      },
+    });
+    await fx.snapshotTicker("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/snapshot/locale/global/markets/forex/tickers/AAPL"
     );
-    await fx.snapshotTicker("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/snapshot/locale/global/markets/forex/tickers/AAPL"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("sma call /v1/indicators/sma/{fxTicker}", async () => {
-    await fx.sma("C:EUR-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/sma/C:EUR-USD");
+    await fx.sma("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/sma/C:EUR-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ema call /v1/indicators/ema/{fxTicker}", async () => {
-    await fx.ema("C:EUR-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/ema/C:EUR-USD");
+    await fx.ema("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/ema/C:EUR-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("macd call /v1/indicators/macd/{fxTicker}", async () => {
-    await fx.macd("C:EUR-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/macd/C:EUR-USD");
+    await fx.macd("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/macd/C:EUR-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("rsi call /v1/indicators/rsi/{fxTicker}", async () => {
-    await fx.rsi("C:EUR-USD");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/rsi/C:EUR-USD");
+    await fx.rsi("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/rsi/C:EUR-USD");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("apiKey and apiBase are passed", async () => {
+    await fx.rsi("C:EUR-USD", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
+    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
   });
 
 });

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -1,7 +1,7 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-import { forexClient } from "./index";
-import * as fetch from "cross-fetch";
+import { forexClient, IForexClient } from "./index.js";
+import fetchModule from '../transport/fetch';
 
 describe("[REST] Forex / Currencies", () => {
   chai.should();
@@ -20,12 +20,12 @@ describe("[REST] Forex / Currencies", () => {
     }
   };
   let fetchStub;
-  let fx;
+  let fx: IForexClient;
   const sandbox = sinon.createSandbox();
   const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
   const setStub = (returnVal, status = 200) => {
     fetchStub?.restore();
-    fetchStub = sandbox.stub(fetch, "default").returns(
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
       Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
     );
     fx = forexClient(mocks.key, mocks.base, mocks.globalOptions);

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -179,7 +179,21 @@ describe("[REST] Forex / Currencies", () => {
     await fx.rsi("C:EUR-USD", mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
-    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].headers.Authorization.should.eql(`Bearer ${mocks.key}`);
+  });
+
+  it("global options are applied if query is not passed in", async () => {
+    await fx.rsi("C:EUR-USD");
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.globalOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("all options are applied if query is undefined", async () => {
+    await fx.rsi("C:EUR-USD", undefined, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
 });

--- a/src/rest/forex/index.ts
+++ b/src/rest/forex/index.ts
@@ -1,21 +1,21 @@
-import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
 import {
   IAggsGroupedDaily,
   IAggsGroupedDailyQuery,
-} from "../stocks/aggregatesGroupedDaily";
+} from "../stocks/aggregatesGroupedDaily.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
-} from "../stocks/previousClose";
-import { ITradesQuotesQuery } from "../stocks/trades";
-import { aggregates } from "./aggregates";
-import { aggregatesGroupedDaily } from "./aggregatesGroupedDaily";
-import { IConversionQuery, IConversion, conversion } from "./conversion";
-import { IForexQuotes, quotes } from "./quotes";
-import { IForexLastQuote, lastQuote } from "./lastQuote";
-import { previousClose } from "./previousClose";
+} from "../stocks/previousClose.js";
+import { ITradesQuotesQuery } from "../stocks/trades.js";
+import { aggregates } from "./aggregates.js";
+import { aggregatesGroupedDaily } from "./aggregatesGroupedDaily.js";
+import { IConversionQuery, IConversion, conversion } from "./conversion.js";
+import { IForexQuotes, quotes } from "./quotes.js";
+import { IForexLastQuote, lastQuote } from "./lastQuote.js";
+import { previousClose } from "./previousClose.js";
 import {
   IForexSnapshotAllTickersQuery,
   IForexSnapshotTickers,
@@ -23,32 +23,32 @@ import {
   snapshotAllTickers,
   snapshotGainersLosers,
   snapshotTicker,
-} from "./snapshots";
-import { ISummaries, ISummariesQuery } from "../stocks/summaries";
-import { summaries } from "./summaries";
-import { ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { ISma, sma } from "./sma";
-import { IEma, ema } from "./ema";
-import { IMacd, macd } from "./macd";
-import { IRsi, rsi } from "./rsi";
+} from "./snapshots.js";
+import { ISummaries, ISummariesQuery } from "../stocks/summaries.js";
+import { summaries } from "./summaries.js";
+import { ITechnicalIndicatorsQuery } from "../stocks/sma.js";
+import { ISma, sma } from "./sma.js";
+import { IEma, ema } from "./ema.js";
+import { IMacd, macd } from "./macd.js";
+import { IRsi, rsi } from "./rsi.js";
 
-export { IConversionQuery, IConversion } from "./conversion";
-export { IForexQuotes } from "./quotes";
-export { IForexLastQuote } from "./lastQuote";
+export { IConversionQuery, IConversion } from "./conversion.js";
+export { IForexQuotes } from "./quotes.js";
+export { IForexLastQuote } from "./lastQuote.js";
 export {
   IRealTimeCurrencyConversionQuery,
   IRealTimeCurrencyConversion,
-} from "./realTimeCurrencyConversion";
+} from "./realTimeCurrencyConversion.js";
 export {
   IForexSnapshotAllTickersQuery,
   IForexSnapshotTickers,
   IForexSnapshot,
-} from "./snapshots";
-export { ISummariesQuery, ISummaries } from '../stocks/summaries';
-export { ISma, ITechnicalIndicatorsQuery } from '../stocks/sma';
-export { IEma } from '../stocks/ema';
-export { IMacd } from '../stocks/macd';
-export { IRsi } from '../stocks/rsi';
+} from "./snapshots.js";
+export { ISummariesQuery, ISummaries } from '../stocks/summaries.js';
+export { ISma, ITechnicalIndicatorsQuery } from '../stocks/sma.js';
+export { IEma } from '../stocks/ema.js';
+export { IMacd } from '../stocks/macd.js';
+export { IRsi } from '../stocks/rsi.js';
 
 export interface IForexClient {
   aggregates: (

--- a/src/rest/forex/index.ts
+++ b/src/rest/forex/index.ts
@@ -1,4 +1,4 @@
-import { auth, IHeaders } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
 import {
@@ -58,59 +58,70 @@ export interface IForexClient {
     from: string,
     to: string,
     query?: IAggsQuery,
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IAggs>;
   aggregatesGroupedDaily: (
     date: string,
-    query?: IAggsGroupedDailyQuery
+    query?: IAggsGroupedDailyQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsGroupedDaily>;
-  summaries: (query?: ISummariesQuery, headers?: IHeaders) => Promise<ISummaries>;
+  summaries: (query?: ISummariesQuery, options?: IRequestOptions) => Promise<ISummaries>;
   conversion: (
     from: string,
     to: string,
-    query?: IConversionQuery
+    query?: IConversionQuery,
+    options?: IRequestOptions
   ) => Promise<IConversion>;
   quotes: (
     fxTicker: string,
-    query?: ITradesQuotesQuery
+    query?: ITradesQuotesQuery,
+    options?: IRequestOptions
   ) => Promise<IForexQuotes>;
-  lastQuote: (from: string, to: string) => Promise<IForexLastQuote>;
+  lastQuote: (from: string, to: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<IForexLastQuote>;
   previousClose: (
     symbol: string,
-    query?: IAggsPreviousCloseQuery
+    query?: IAggsPreviousCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsPreviousClose>;
   snapshotAllTickers: (
-    query?: IForexSnapshotAllTickersQuery
+    query?: IForexSnapshotAllTickersQuery,
+    options?: IRequestOptions
   ) => Promise<IForexSnapshotTickers>;
   snapshotGainersLosers: (
-    direction: "gainers" | "losers"
+    direction: "gainers" | "losers",
+    query?: IPolygonQuery,
+    options?: IRequestOptions
   ) => Promise<IForexSnapshotTickers>;
-  snapshotTicker: (symbol: string) => Promise<IForexSnapshot>;
-  sma: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<ISma>;
-  ema: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IEma>;
-  macd: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IMacd>;
-  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IRsi>;
+  snapshotTicker: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<IForexSnapshot>;
+  sma: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<ISma>;
+  ema: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IEma>;
+  macd: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IMacd>;
+  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IRsi>;
 }
 
 export const forexClient = (
   apiKey: string,
   apiBase = "https://api.polygon.io",
-  headers?: IHeaders
-): IForexClient => ({
-  aggregates: auth(apiKey, aggregates, apiBase, headers),
-  aggregatesGroupedDaily: auth(apiKey, aggregatesGroupedDaily, apiBase),
-  summaries: auth(apiKey, summaries, apiBase, headers),
-  conversion: auth(apiKey, conversion, apiBase),
-  quotes: auth(apiKey, quotes, apiBase),
-  lastQuote: auth(apiKey, lastQuote, apiBase),
-  previousClose: auth(apiKey, previousClose, apiBase),
-  snapshotAllTickers: auth(apiKey, snapshotAllTickers, apiBase),
-  snapshotGainersLosers: auth(apiKey, snapshotGainersLosers, apiBase),
-  snapshotTicker: auth(apiKey, snapshotTicker, apiBase),
-  sma: auth(apiKey, sma, apiBase), 
-  ema: auth(apiKey, ema, apiBase), 
-  macd: auth(apiKey, macd, apiBase), 
-  rsi: auth(apiKey, rsi, apiBase)
-});
+  options?: IRequestOptions
+): IForexClient => {
+  const get = getWithGlobals(apiKey, apiBase, options);
+    
+  return ({
+    aggregates: (...args) => aggregates(get, ...args),
+    aggregatesGroupedDaily: (...args) => aggregatesGroupedDaily(get, ...args),
+    summaries: (...args) => summaries(get, ...args),
+    conversion: (...args) => conversion(get, ...args),
+    quotes: (...args) => quotes(get, ...args),
+    lastQuote: (...args) => lastQuote(get, ...args),
+    previousClose: (...args) => previousClose(get, ...args),
+    snapshotAllTickers: (...args) => snapshotAllTickers(get, ...args),
+    snapshotGainersLosers: (...args) => snapshotGainersLosers(get, ...args),
+    snapshotTicker: (...args) => snapshotTicker(get, ...args),
+    sma: (...args) => sma(get, ...args),
+    ema: (...args) => ema(get, ...args),
+    macd: (...args) => macd(get, ...args),
+    rsi: (...args) => rsi(get, ...args)
+  })
+};
 
 export default forexClient;

--- a/src/rest/forex/lastQuote.ts
+++ b/src/rest/forex/lastQuote.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_last_quote_currencies__from___to
 
-import { get } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IForexLastQuote {
   status?: string;
@@ -15,9 +15,10 @@ export interface IForexLastQuote {
 }
 
 export const lastQuote = (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   from: string,
-  to: string
+  to: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<IForexLastQuote> =>
-  get(`/v1/last_quote/currencies/${from}/${to}`, apiKey, apiBase);
+  get(`/v1/last_quote/currencies/${from}/${to}`, query, options);

--- a/src/rest/forex/lastQuote.ts
+++ b/src/rest/forex/lastQuote.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_last_quote_currencies__from___to
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IForexLastQuote {
   status?: string;

--- a/src/rest/forex/macd.ts
+++ b/src/rest/forex/macd.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IMacd } from '../stocks/macd';
 
 export const macd = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, query, options);

--- a/src/rest/forex/macd.ts
+++ b/src/rest/forex/macd.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IMacd } from '../stocks/macd';
 

--- a/src/rest/forex/previousClose.ts
+++ b/src/rest/forex/previousClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_ticker__forexTicker__prev
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,

--- a/src/rest/forex/previousClose.ts
+++ b/src/rest/forex/previousClose.ts
@@ -1,15 +1,15 @@
 // CF: https://polygon.io/docs/forex/get_v2_aggs_ticker__forexTicker__prev
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
 } from "../stocks/previousClose";
 
 export const previousClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
-  query?: IAggsPreviousCloseQuery
+  query?: IAggsPreviousCloseQuery,
+  options?: IRequestOptions
 ): Promise<IAggsPreviousClose> =>
-  get(`/v2/aggs/ticker/${symbol}/prev`, apiKey, apiBase, query);
+  get(`/v2/aggs/ticker/${symbol}/prev`, query, options);

--- a/src/rest/forex/quotes.ts
+++ b/src/rest/forex/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_historic_forex__from___to___date
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IForexQuotesInfo {

--- a/src/rest/forex/quotes.ts
+++ b/src/rest/forex/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_historic_forex__from___to___date
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IForexQuotesInfo {
@@ -19,9 +19,9 @@ export interface IForexQuotes {
 }
 
 export const quotes = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   fxTicker: string,
-  query?: ITradesQuotesQuery
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
 ): Promise<IForexQuotes> =>
-  get(`/v3/quotes/${fxTicker}`, apiKey, apiBase, query);
+  get(`/v3/quotes/${fxTicker}`, query, options);

--- a/src/rest/forex/realTimeCurrencyConversion.ts
+++ b/src/rest/forex/realTimeCurrencyConversion.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_conversion__from___to
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface IRealTimeCurrencyConversionQuery extends IPolygonQuery {
   amount?: number;

--- a/src/rest/forex/realTimeCurrencyConversion.ts
+++ b/src/rest/forex/realTimeCurrencyConversion.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/get_v1_conversion__from___to
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface IRealTimeCurrencyConversionQuery extends IPolygonQuery {
   amount?: number;
@@ -23,10 +23,10 @@ export interface IRealTimeCurrencyConversion {
 }
 
 export const realTimeCurrencyConversion = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   from: string,
   to: string,
-  query?: IRealTimeCurrencyConversionQuery
+  query?: IRealTimeCurrencyConversionQuery,
+  options?: IRequestOptions
 ): Promise<IRealTimeCurrencyConversion> =>
-  get(`/v1/conversion/${from}/${to}`, apiKey, apiBase, query);
+  get(`/v1/conversion/${from}/${to}`, query, options);

--- a/src/rest/forex/rsi.ts
+++ b/src/rest/forex/rsi.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IRsi } from '../stocks/rsi';
 

--- a/src/rest/forex/rsi.ts
+++ b/src/rest/forex/rsi.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IRsi } from '../stocks/rsi';
 
 export const rsi = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, query, options);

--- a/src/rest/forex/sma.ts
+++ b/src/rest/forex/sma.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/forex/get_v1_indicators_sma__fxticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { ISma } from '../stocks/sma';
 

--- a/src/rest/forex/sma.ts
+++ b/src/rest/forex/sma.ts
@@ -1,13 +1,13 @@
 // CF: https://polygon.io/docs/forex/get_v1_indicators_sma__fxticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { ISma } from '../stocks/sma';
 
 export const sma = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, query, options);

--- a/src/rest/forex/snapshots.ts
+++ b/src/rest/forex/snapshots.ts
@@ -1,4 +1,4 @@
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface SnapshotDay {
   c?: number;

--- a/src/rest/forex/snapshots.ts
+++ b/src/rest/forex/snapshots.ts
@@ -1,4 +1,4 @@
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface SnapshotDay {
   c?: number;
@@ -61,33 +61,34 @@ export interface IForexSnapshot {
 
 // CF: https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers
 export const snapshotAllTickers = async (
-  apiKey: string,
-  apiBase: string,
-  query?: IForexSnapshotAllTickersQuery
+  get: IGet,
+  query?: IForexSnapshotAllTickersQuery,
+  options?: IRequestOptions
 ): Promise<IForexSnapshotTickers> =>
   get(
     `/v2/snapshot/locale/global/markets/forex/tickers`,
-    apiKey,
-    apiBase,
-    query
+    query,
+    options
   );
 
 // CF: https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex__direction
 export const snapshotGainersLosers = async (
-  apiKey: string,
-  apiBase: string,
-  direction: "gainers" | "losers"
+  get: IGet,
+  direction: "gainers" | "losers",
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<IForexSnapshotTickers> =>
-  get(`/v2/snapshot/locale/global/markets/forex/${direction}`, apiKey, apiBase);
+  get(`/v2/snapshot/locale/global/markets/forex/${direction}`, query, options);
 
 // CF: https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers__ticker
 export const snapshotTicker = async (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<IForexSnapshot> =>
   get(
     `/v2/snapshot/locale/global/markets/forex/tickers/${symbol}`,
-    apiKey,
-    apiBase
+    query,
+    options
   );

--- a/src/rest/forex/summaries.ts
+++ b/src/rest/forex/summaries.ts
@@ -1,18 +1,15 @@
 // CF: https://polygon.io/docs/forex/launchpad/get_v1_summaries
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   query?: ISummariesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<ISummaries> =>
   get(
     `/v1/summaries`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/forex/summaries.ts
+++ b/src/rest/forex/summaries.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/forex/launchpad/get_v1_summaries
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (

--- a/src/rest/index.test.ts
+++ b/src/rest/index.test.ts
@@ -1,5 +1,5 @@
 import * as chai from "chai";
-import { restClient } from "./index";
+import { restClient } from "./index.js";
 
 describe("[EXPORT] REST Endpoints", () => {
   chai.should();

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -1,14 +1,14 @@
-import { cryptoClient, ICryptoClient } from "./crypto";
-import { forexClient, IForexClient } from "./forex";
-import { referenceClient, IReferenceClient } from "./reference";
-import { optionsClient, IOptionsClient } from "./options";
-import { stocksClient, IStocksClient } from "./stocks";
-import { IRequestOptions } from "./transport/request";
-export * from "./crypto";
-export * from "./forex";
-export * from "./reference";
-export * from "./options";
-export * from "./stocks";
+import { cryptoClient, ICryptoClient } from "./crypto/index.js";
+import { forexClient, IForexClient } from "./forex/index.js";
+import { referenceClient, IReferenceClient } from "./reference/index.js";
+import { optionsClient, IOptionsClient } from "./options/index.js";
+import { stocksClient, IStocksClient } from "./stocks/index.js";
+import { IRequestOptions } from "./transport/request.js";
+export * from "./crypto/index.js";
+export * from "./forex/index.js";
+export * from "./reference/index.js";
+export * from "./options/index.js";
+export * from "./stocks/index.js";
 
 export interface IRestClient {
   crypto: ICryptoClient;

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -3,7 +3,7 @@ import { forexClient, IForexClient } from "./forex";
 import { referenceClient, IReferenceClient } from "./reference";
 import { optionsClient, IOptionsClient } from "./options";
 import { stocksClient, IStocksClient } from "./stocks";
-import { IHeaders } from "./transport/request";
+import { IRequestOptions } from "./transport/request";
 export * from "./crypto";
 export * from "./forex";
 export * from "./reference";
@@ -18,12 +18,12 @@ export interface IRestClient {
   stocks: IStocksClient;
 }
 
-export const restClient = (apiKey, apiBase?: string, headers?: IHeaders): IRestClient => ({
-  crypto: cryptoClient(apiKey, apiBase, headers),
-  forex: forexClient(apiKey, apiBase, headers),
-  reference: referenceClient(apiKey, apiBase, headers),
-  options: optionsClient(apiKey, apiBase, headers),
-  stocks: stocksClient(apiKey, apiBase, headers),
+export const restClient = (apiKey, apiBase?: string, options?: IRequestOptions): IRestClient => ({
+  crypto: cryptoClient(apiKey, apiBase, options),
+  forex: forexClient(apiKey, apiBase, options),
+  reference: referenceClient(apiKey, apiBase, options),
+  options: optionsClient(apiKey, apiBase, options),
+  stocks: stocksClient(apiKey, apiBase, options),
 });
 
 export default restClient;

--- a/src/rest/options/aggregates.ts
+++ b/src/rest/options/aggregates.ts
@@ -1,23 +1,20 @@
 // CF: https://polygon.io/docs/options/get_v2_aggs_ticker__optionsTicker__range__multiplier___timespan___from___to
 
-import { get, IHeaders } from "../transport/request";
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export const aggregates = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string,
   to: string,
   query?: IAggsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IAggs> =>
   get(
     `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/options/aggregates.ts
+++ b/src/rest/options/aggregates.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/options/get_v2_aggs_ticker__optionsTicker__range__multiplier___timespan___from___to
 
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export const aggregates = async (
   get: IGet,

--- a/src/rest/options/dailyOpenClose.ts
+++ b/src/rest/options/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v1_open-close__optionsTicker___date
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IOptionsDailyOpenCloseQuery extends IPolygonQuery {
   adjusted?: "true" | "false";

--- a/src/rest/options/dailyOpenClose.ts
+++ b/src/rest/options/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v1_open-close__optionsTicker___date
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IOptionsDailyOpenCloseQuery extends IPolygonQuery {
   adjusted?: "true" | "false";
@@ -20,10 +20,10 @@ export interface IOptionsDailyOpenClose {
 }
 
 export const dailyOpenClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
   date: string,
-  query?: IOptionsDailyOpenCloseQuery
+  query?: IOptionsDailyOpenCloseQuery,
+  options?: IRequestOptions
 ): Promise<IOptionsDailyOpenClose> =>
-  get(`/v1/open-close/${symbol}/${date}`, apiKey, apiBase, query);
+  get(`/v1/open-close/${symbol}/${date}`, query, options);

--- a/src/rest/options/ema.ts
+++ b/src/rest/options/ema.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IEma } from '../stocks/ema';
 
 export const ema = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, query, options);

--- a/src/rest/options/ema.ts
+++ b/src/rest/options/ema.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IEma } from "../stocks/ema";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IEma } from '../stocks/ema';
 

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -153,6 +153,20 @@ describe("[REST] Options", () => {
     await options.rsi("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
-    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].headers.Authorization.should.eql(`Bearer ${mocks.key}`);
+  });
+
+  it("global options are applied if query is not passed in", async () => {
+    await options.rsi("O:AAPL230616C00150000");
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.globalOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("all options are applied if query is undefined", async () => {
+    await options.rsi("O:AAPL230616C00150000", undefined, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 });

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -1,8 +1,8 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
 
-import * as fetch from "cross-fetch";
-import { optionsClient } from "./index";
+import fetchModule from '../transport/fetch';
+import { IOptionsClient, optionsClient } from "./index.js";
 
 describe("[REST] Options", () => {
   chai.should();
@@ -21,12 +21,12 @@ describe("[REST] Options", () => {
     }
   };
   let fetchStub;
-  let options;
+  let options: IOptionsClient;
   const sandbox = sinon.createSandbox();
   const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
   const setStub = (returnVal, status = 200) => {
     fetchStub?.restore();
-    fetchStub = sandbox.stub(fetch, "default").returns(
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
       Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
     );
     options = optionsClient(mocks.key, mocks.base, mocks.globalOptions);

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -1,112 +1,158 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
 
-import * as request from "../transport/request";
+import * as fetch from "cross-fetch";
 import { optionsClient } from "./index";
 
 describe("[REST] Options", () => {
   chai.should();
-  let requestStub;
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  let options;
   const sandbox = sinon.createSandbox();
-  const options = optionsClient("invalid");
-  beforeEach(() => {
-    requestStub = sandbox
-      .stub(request, "get")
-      .returns(Promise.resolve({ ticks: [], results: [], tickers: [] }));
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetch, "default").returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+    options = optionsClient(mocks.key, mocks.base, mocks.globalOptions);
+  }
+  beforeEach(async () => {
+    setStub({});
   });
   afterEach(() => {
     sandbox.restore();
   });
 
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await options.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
     );
-    await options.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("daily open close call /v1/open-close/{symbol}/{date}", async () => {
-    await options.dailyOpenClose("AAPL", "2018-2-2");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v1/open-close/AAPL/2018-2-2");
+    await options.dailyOpenClose("AAPL", "2018-2-2", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/open-close/AAPL/2018-2-2");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("previous close call /v2/aggs/ticker/{optionsTicker}/prev", async () => {
-    await options.previousClose("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/aggs/ticker/AAPL/prev");
+    await options.previousClose("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/aggs/ticker/AAPL/prev");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("trades call /v3/trades/{optionsTicker}", async () => {
-    await options.trades("O:TSLA210903C00700000");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v3/trades/O:TSLA210903C00700000");
+    await options.trades("O:TSLA210903C00700000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/trades/O:TSLA210903C00700000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("last trade call /v2/last/trade/{optionsTicker}", async () => {
-    await options.lastTrade("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/last/trade/AAPL");
+    await options.lastTrade("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/last/trade/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("quotes call /v3/quotes/{optionsTicker}  ", async () => {
-    await options.quotes("O:SPY241220P00720000");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v3/quotes/O:SPY241220P00720000");
+    await options.quotes("O:SPY241220P00720000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/quotes/O:SPY241220P00720000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - option contract call /v3/snapshot/options/{underlyingAsset}/{optionContract}", async () => {
-    await options.snapshotOptionContract("AAPL", "O:AAPL230616C00150000");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v3/snapshot/options/AAPL/O:AAPL230616C00150000");
+    await options.snapshotOptionContract("AAPL", "O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/snapshot/options/AAPL/O:AAPL230616C00150000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshots - option chain /v3/snapshot/options/{underlyingAsset}", async () => {
-    await options.snapshotOptionChain("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v3/snapshot/options/AAPL");
+    await options.snapshotOptionChain("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/snapshot/options/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("sma call /v1/indicators/sma/{optionTicker}", async () => {
-    await options.sma("O:AAPL230616C00150000");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/sma/O:AAPL230616C00150000");
+    await options.sma("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/sma/O:AAPL230616C00150000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ema call /v1/indicators/ema/{optionTicker}", async () => {
-    await options.ema("O:AAPL230616C00150000");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/ema/O:AAPL230616C00150000");
+    await options.ema("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/ema/O:AAPL230616C00150000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("macd call /v1/indicators/macd/{optionTicker}", async () => {
-    await options.macd("O:AAPL230616C00150000");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/macd/O:AAPL230616C00150000");
+    await options.macd("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/macd/O:AAPL230616C00150000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("rsi call /v1/indicators/rsi/{optionTicker}", async () => {
-    await options.rsi("O:AAPL230616C00150000");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/rsi/O:AAPL230616C00150000");
+    await options.rsi("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/rsi/O:AAPL230616C00150000");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("apiKey and apiBase are passed", async () => {
+    await options.rsi("O:AAPL230616C00150000", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
+    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
   });
 });

--- a/src/rest/options/index.ts
+++ b/src/rest/options/index.ts
@@ -1,5 +1,4 @@
-import { auth, IHeaders } from "../transport/request";
-
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
 import { IAggsQuery, IAggs } from "../stocks/aggregates";
 import {
   IAggsPreviousCloseQuery,
@@ -59,59 +58,70 @@ export interface IOptionsClient {
     from: string,
     to: string,
     query?: IAggsQuery,
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IAggs>;
-  summaries: (query?: ISummariesQuery, headers?: IHeaders) => Promise<ISummaries>;
+  summaries: (query?: ISummariesQuery, options?: IRequestOptions) => Promise<ISummaries>;
   dailyOpenClose: (
     symbol: string,
     date: string,
-    query?: IOptionsDailyOpenCloseQuery
+    query?: IOptionsDailyOpenCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IOptionsDailyOpenClose>;
   previousClose: (
     symbol: string,
-    query?: IAggsPreviousCloseQuery
+    query?: IAggsPreviousCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsPreviousClose>;
   trades: (
     optionsTicker: string,
-    query?: ITradesQuotesQuery
+    query?: ITradesQuotesQuery,
+    options?: IRequestOptions
   ) => Promise<IOptionTrades>;
-  lastTrade: (symbol: string) => Promise<IOptionsLastTrade>;
+  lastTrade: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<IOptionsLastTrade>;
   quotes: (
     optionsTicker: string,
-    query?: ITradesQuotesQuery
+    query?: ITradesQuotesQuery,
+    options?: IRequestOptions
   ) => Promise<IOptionQuotes>;
   snapshotOptionContract: (
     underlyingAsset: string,
-    optionContract: string
+    optionContract: string,
+    query?: IPolygonQuery,
+    options?: IRequestOptions
   ) => Promise<IOptionsSnapshotContract>;
   snapshotOptionChain: (
     underlyingAsset: string,
-    query?: IOptionsChainQuery
+    query?: IOptionsChainQuery,
+    options?: IRequestOptions
   ) => Promise<IOptionsSnapshotChain>;
-  sma: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<ISma>;
-  ema: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IEma>;
-  macd: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IMacd>;
-  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IRsi>;
+  sma: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<ISma>;
+  ema: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IEma>;
+  macd: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IMacd>;
+  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IRsi>;
 }
 
 export const optionsClient = (
   apiKey: string,
   apiBase = "https://api.polygon.io",
-  headers?: IHeaders
-): IOptionsClient => ({
-  aggregates: auth(apiKey, aggregates, apiBase, headers),
-  summaries: auth(apiKey, summaries, apiBase, headers),
-  dailyOpenClose: auth(apiKey, dailyOpenClose, apiBase),
-  previousClose: auth(apiKey, previousClose, apiBase),
-  trades: auth(apiKey, trades, apiBase),
-  lastTrade: auth(apiKey, lastTrade, apiBase),
-  quotes: auth(apiKey, quotes, apiBase),
-  snapshotOptionContract: auth(apiKey, snapshotOptionContract, apiBase),
-  snapshotOptionChain: auth(apiKey, snapshotOptionChain, apiBase),
-  sma: auth(apiKey, sma, apiBase), 
-  ema: auth(apiKey, ema, apiBase), 
-  macd: auth(apiKey, macd, apiBase), 
-  rsi: auth(apiKey, rsi, apiBase)
-});
+  options?: IRequestOptions
+): IOptionsClient => {
+  const get = getWithGlobals(apiKey, apiBase, options)
+  
+  return ({
+    aggregates: (...args) => aggregates(get, ...args),
+    summaries: (...args) => summaries(get, ...args),
+    dailyOpenClose: (...args) => dailyOpenClose(get, ...args),
+    previousClose: (...args) => previousClose(get, ...args),
+    trades: (...args) => trades(get, ...args),
+    lastTrade: (...args) => lastTrade(get, ...args),
+    quotes: (...args) => quotes(get, ...args),
+    snapshotOptionContract: (...args) => snapshotOptionContract(get, ...args),
+    snapshotOptionChain: (...args) => snapshotOptionChain(get, ...args),
+    sma: (...args) => sma(get, ...args),
+    ema: (...args) => ema(get, ...args),
+    macd: (...args) => macd(get, ...args),
+    rsi: (...args) => rsi(get, ...args)
+  })
+};
 
 export default optionsClient;

--- a/src/rest/options/index.ts
+++ b/src/rest/options/index.ts
@@ -1,54 +1,54 @@
-import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
-import { IAggsQuery, IAggs } from "../stocks/aggregates";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request.js";
+import { IAggsQuery, IAggs } from "../stocks/aggregates.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
-} from "../stocks/previousClose";
-import { ITradesQuotesQuery } from "../stocks/trades";
-import { aggregates } from "./aggregates";
+} from "../stocks/previousClose.js";
+import { ITradesQuotesQuery } from "../stocks/trades.js";
+import { aggregates } from "./aggregates.js";
 import {
   IOptionsDailyOpenCloseQuery,
   IOptionsDailyOpenClose,
   dailyOpenClose,
-} from "./dailyOpenClose";
-import { previousClose } from "./previousClose";
-import { IOptionTrades, trades } from "./trades";
-import { IOptionsLastTrade, lastTrade } from "./lastTrade";
-import { IOptionQuotes, quotes } from "./quotes";
+} from "./dailyOpenClose.js";
+import { previousClose } from "./previousClose.js";
+import { IOptionTrades, trades } from "./trades.js";
+import { IOptionsLastTrade, lastTrade } from "./lastTrade.js";
+import { IOptionQuotes, quotes } from "./quotes.js";
 import {
   IOptionsSnapshotContract,
   IOptionsSnapshotChain,
   IOptionsChainQuery,
   snapshotOptionContract,
   snapshotOptionChain
-} from "./snapshots";
-import { ISummaries, ISummariesQuery } from "../stocks/summaries";
-import { summaries } from "./summaries";
-import { ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { ISma, sma } from "./sma";
-import { IEma, ema } from "./ema";
-import { IMacd, macd } from "./macd";
-import { IRsi, rsi } from "./rsi";
+} from "./snapshots.js";
+import { ISummaries, ISummariesQuery } from "../stocks/summaries.js";
+import { summaries } from "./summaries.js";
+import { ITechnicalIndicatorsQuery } from "../stocks/sma.js";
+import { ISma, sma } from "./sma.js";
+import { IEma, ema } from "./ema.js";
+import { IMacd, macd } from "./macd.js";
+import { IRsi, rsi } from "./rsi.js";
 
 export {
   IOptionsDailyOpenCloseQuery,
   IOptionsDailyOpenClose,
-} from "./dailyOpenClose";
-export { IOptionTrades } from "./trades";
-export { IOptionsLastTrade } from "./lastTrade";
-export { IOptionQuotes } from "./quotes";
+} from "./dailyOpenClose.js";
+export { IOptionTrades } from "./trades.js";
+export { IOptionsLastTrade } from "./lastTrade.js";
+export { IOptionQuotes } from "./quotes.js";
 export {
   IOptionsSnapshotContract,
   IOptionsSnapshotChain,
   IOptionsChainQuery,
   snapshotOptionContract,
   snapshotOptionChain,
-} from "./snapshots";
-export { ISummariesQuery, ISummaries } from '../stocks/summaries';
-export { ISma, ITechnicalIndicatorsQuery } from '../stocks/sma';
-export { IEma } from '../stocks/ema';
-export { IMacd } from '../stocks/macd';
-export { IRsi } from '../stocks/rsi';
+} from "./snapshots.js";
+export { ISummariesQuery, ISummaries } from '../stocks/summaries.js';
+export { ISma, ITechnicalIndicatorsQuery } from '../stocks/sma.js';
+export { IEma } from '../stocks/ema.js';
+export { IMacd } from '../stocks/macd.js';
+export { IRsi } from '../stocks/rsi.js';
 
 export interface IOptionsClient {
   aggregates: (

--- a/src/rest/options/lastTrade.ts
+++ b/src/rest/options/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v2_last_trade__optionsTicker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 import { ILastTradeInfo } from "../stocks/lastTrade";
 
 export interface IOptionsLastTrade {

--- a/src/rest/options/lastTrade.ts
+++ b/src/rest/options/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v2_last_trade__optionsTicker
 
-import { get } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 import { ILastTradeInfo } from "../stocks/lastTrade";
 
 export interface IOptionsLastTrade {
@@ -10,8 +10,9 @@ export interface IOptionsLastTrade {
 }
 
 export const lastTrade = async (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<IOptionsLastTrade> =>
-  get(`/v2/last/trade/${symbol}`, apiKey, apiBase);
+  get(`/v2/last/trade/${symbol}`, query, options);

--- a/src/rest/options/macd.ts
+++ b/src/rest/options/macd.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IMacd } from '../stocks/macd';
 
 export const macd = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, query, options);

--- a/src/rest/options/macd.ts
+++ b/src/rest/options/macd.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IMacd } from "../stocks/macd";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IMacd } from '../stocks/macd';
 

--- a/src/rest/options/previousClose.ts
+++ b/src/rest/options/previousClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v2_aggs_ticker__optionsTicker__prev
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,

--- a/src/rest/options/previousClose.ts
+++ b/src/rest/options/previousClose.ts
@@ -1,15 +1,15 @@
 // CF: https://polygon.io/docs/options/get_v2_aggs_ticker__optionsTicker__prev
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
 } from "../stocks/previousClose";
 
 export const previousClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
-  query?: IAggsPreviousCloseQuery
+  query?: IAggsPreviousCloseQuery,
+  options?: IRequestOptions
 ): Promise<IAggsPreviousClose> =>
-  get(`/v2/aggs/ticker/${symbol}/prev`, apiKey, apiBase, query);
+  get(`/v2/aggs/ticker/${symbol}/prev`, query, options);

--- a/src/rest/options/quotes.ts
+++ b/src/rest/options/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_quotes__optionsticker
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IOptionQuotesInfo {

--- a/src/rest/options/quotes.ts
+++ b/src/rest/options/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_quotes__optionsticker
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IOptionQuotesInfo {
@@ -22,9 +22,9 @@ export interface IOptionQuotes {
 }
 
 export const quotes = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   optionsTicker: string,
-  query?: ITradesQuotesQuery
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
 ): Promise<IOptionQuotes> =>
-  get(`/v3/quotes/${optionsTicker}`, apiKey, apiBase, query);
+  get(`/v3/quotes/${optionsTicker}`, query, options);

--- a/src/rest/options/rsi.ts
+++ b/src/rest/options/rsi.ts
@@ -2,7 +2,7 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { IRsi } from '../stocks/rsi';
 

--- a/src/rest/options/rsi.ts
+++ b/src/rest/options/rsi.ts
@@ -2,13 +2,13 @@
 
 import { ITechnicalIndicatorsQuery } from "../stocks/sma";
 import { IRsi } from "../stocks/rsi";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { IRsi } from '../stocks/rsi';
 
 export const rsi = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, query, options);

--- a/src/rest/options/sma.ts
+++ b/src/rest/options/sma.ts
@@ -1,13 +1,13 @@
 // CF: https://polygon.io/docs/options/get_v1_indicators_sma__optionsticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export { ISma } from '../stocks/sma';
 
 export const sma = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, query, options);

--- a/src/rest/options/sma.ts
+++ b/src/rest/options/sma.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/options/get_v1_indicators_sma__optionsticker
 
 import { ISma, ITechnicalIndicatorsQuery } from "../stocks/sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export { ISma } from '../stocks/sma';
 

--- a/src/rest/options/snapshots.ts
+++ b/src/rest/options/snapshots.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_snapshot_options__underlyingAsset___optionContract
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface SnapshotDay {
   change?: number;

--- a/src/rest/options/snapshots.ts
+++ b/src/rest/options/snapshots.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_snapshot_options__underlyingAsset___optionContract
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface SnapshotDay {
   change?: number;
@@ -94,26 +94,22 @@ export interface IOptionsChainQuery extends IPolygonQuery {
 }
 
 export const snapshotOptionChain = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   underlyingAsset: string,
-  query?: IOptionsChainQuery
+  query?: IOptionsChainQuery,
+  options?: IRequestOptions
 ): Promise<IOptionsSnapshotChain> =>
-  get(
-    `/v3/snapshot/options/${underlyingAsset}`,
-    apiKey,
-    apiBase,
-    query
-  );
+  get(`/v3/snapshot/options/${underlyingAsset}`, query, options);
 
 export const snapshotOptionContract = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   underlyingAsset: string,
-  optionContract: string
+  optionContract: string,
+  query?: IOptionsChainQuery,
+  options?: IRequestOptions
 ): Promise<IOptionsSnapshotContract> =>
   get(
     `/v3/snapshot/options/${underlyingAsset}/${optionContract}`,
-    apiKey,
-    apiBase
+    query,
+    options
   );

--- a/src/rest/options/summaries.ts
+++ b/src/rest/options/summaries.ts
@@ -1,18 +1,11 @@
 // CF: https://polygon.io/docs/options/launchpad/get_v1_summaries
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   query?: ISummariesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<ISummaries> =>
-  get(
-    `/v1/summaries`,
-    apikey,
-    apiBase,
-    query,
-    headers
-  );
+  get(`/v1/summaries`, query, options);

--- a/src/rest/options/summaries.ts
+++ b/src/rest/options/summaries.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/launchpad/get_v1_summaries
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ISummaries, ISummariesQuery } from "../stocks/summaries";
 
 export const summaries = async (

--- a/src/rest/options/trades.ts
+++ b/src/rest/options/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_trades__optionsticker
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IOptionTradesInfo {

--- a/src/rest/options/trades.ts
+++ b/src/rest/options/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_trades__optionsticker
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ITradesQuotesQuery } from "../stocks/trades";
 
 export interface IOptionTradesInfo {
@@ -21,9 +21,9 @@ export interface IOptionTrades {
 }
 
 export const trades = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   optionsTicker: string,
-  query?: ITradesQuotesQuery
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
 ): Promise<IOptionTrades> =>
-  get(`/v3/trades/${optionsTicker}`, apiKey, apiBase, query);
+  get(`/v3/trades/${optionsTicker}`, query, options);

--- a/src/rest/reference/conditions.ts
+++ b/src/rest/reference/conditions.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_conditions
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IConditionsQuery extends IPolygonQuery {
   asset_class?: "stocks" | "options" | "crypto" | "fx";
@@ -51,9 +51,8 @@ export interface IConditions {
 }
 
 export const conditions = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IConditionsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IConditions> =>
-  get("/v3/reference/conditions", apiKey, apiBase, query, headers);
+  get("/v3/reference/conditions", query, options);

--- a/src/rest/reference/conditions.ts
+++ b/src/rest/reference/conditions.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_conditions
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IConditionsQuery extends IPolygonQuery {
   asset_class?: "stocks" | "options" | "crypto" | "fx";

--- a/src/rest/reference/dividends.ts
+++ b/src/rest/reference/dividends.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_dividends__stocksTicker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IDividend {
   cash_amount: number;

--- a/src/rest/reference/dividends.ts
+++ b/src/rest/reference/dividends.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_dividends__stocksTicker
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IDividend {
   cash_amount: number;
@@ -65,9 +65,8 @@ export interface IDividendsQuery extends IPolygonQuery {
 }
 
 export const stockDividends = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IDividendsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IDividendsResults> =>
-  get(`/v3/reference/dividends`, apiKey, apiBase, query, headers);
+  get(`/v3/reference/dividends`, query, options);

--- a/src/rest/reference/exchanges.ts
+++ b/src/rest/reference/exchanges.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_exchanges
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IExchangesQuery extends IPolygonQuery {
   asset_class?: "stocks" | "options" | "crypto" | "fx";

--- a/src/rest/reference/exchanges.ts
+++ b/src/rest/reference/exchanges.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_exchanges
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IExchangesQuery extends IPolygonQuery {
   asset_class?: "stocks" | "options" | "crypto" | "fx";
@@ -28,9 +28,8 @@ export interface IExchanges {
 }
 
 export const exchanges = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IExchangesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IExchanges> =>
-  get("/v3/reference/exchanges", apiKey, apiBase, query, headers);
+  get("/v3/reference/exchanges", query, options);

--- a/src/rest/reference/index.test.ts
+++ b/src/rest/reference/index.test.ts
@@ -1,103 +1,166 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-
-import * as request from "../transport/request";
+import * as fetch from "cross-fetch";
 
 import { referenceClient } from "./index";
 
 describe("[REST] Reference", () => {
   chai.should();
-  let requestStub;
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  let ref;
   const sandbox = sinon.createSandbox();
-  const ref = referenceClient("invalid");
-  beforeEach(() => {
-    requestStub = sandbox.stub(request, "get").returns(Promise.resolve({}));
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetch, "default").returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+    ref = referenceClient(mocks.key, mocks.base, mocks.globalOptions);
+  }
+  beforeEach(async () => {
+    setStub({});
   });
   afterEach(() => {
     sandbox.restore();
   });
 
   it("conditions call /v3/reference/conditions", async () => {
-    await ref.conditions();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/conditions");
+    await ref.conditions(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/conditions");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("exchanges call /v3/reference/exchanges", async () => {
-    await ref.exchanges();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/exchanges");
+    await ref.exchanges(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/exchanges");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("market holidays call /v1/marketstatus/upcoming", async () => {
-    await ref.marketHolidays();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/marketstatus/upcoming");
+    await ref.marketHolidays(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/marketstatus/upcoming");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("market status call /v1/marketstatus/now", async () => {
-    await ref.marketStatus();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/marketstatus/now");
+    await ref.marketStatus(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/marketstatus/now");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("options contract call /v3/reference/options/contracts/{options_ticker}", async () => {
-    await ref.optionsContract("O:EVRI240119C00002500");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v3/reference/options/contracts/O:EVRI240119C00002500"
-      );
+    await ref.optionsContract("O:EVRI240119C00002500", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v3/reference/options/contracts/O:EVRI240119C00002500"
+    );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("options contracts call /v3/reference/options/contracts", async () => {
-    await ref.optionsContracts();
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v3/reference/options/contracts");
+    await ref.optionsContracts(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/options/contracts");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("stock dividends call /v3/reference/dividends", async () => {
-    await ref.dividends();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/dividends");
+    await ref.dividends(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/dividends");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("stock splits call /v3/reference/splits", async () => {
-    await ref.stockSplits();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/splits");
+    await ref.stockSplits(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/splits");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("stock financials call /vX/reference/financials", async () => {
-    await ref.stockFinancials();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/vX/reference/financials");
+    await ref.stockFinancials(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/vX/reference/financials");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ticker details call /v3/reference/tickers/{ticker}", async () => {
-    await ref.tickerDetails("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/tickers/AAPL");
+    await ref.tickerDetails("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/tickers/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ticker news call /v2/reference/news", async () => {
-    await ref.tickerNews();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/reference/news");
+    await ref.tickerNews(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/reference/news");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("tickers call /v2/reference/tickers", async () => {
-    await ref.tickers();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/tickers");
+    await ref.tickers(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/tickers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ticker types call /v3/reference/tickers/types", async () => {
-    await ref.tickerTypes();
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/reference/tickers/types");
+    await ref.tickerTypes(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/reference/tickers/types");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("apiKey and apiBase are passed", async () => {
+    await ref.tickerTypes(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
+    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
   });
 });

--- a/src/rest/reference/index.test.ts
+++ b/src/rest/reference/index.test.ts
@@ -161,6 +161,20 @@ describe("[REST] Reference", () => {
     await ref.tickerTypes(mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
-    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].headers.Authorization.should.eql(`Bearer ${mocks.key}`);
+  });
+
+  it("global options are applied if query is not passed in", async () => {
+    await ref.tickers();
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.globalOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("all options are applied if query is undefined", async () => {
+    await ref.tickers(undefined, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 });

--- a/src/rest/reference/index.test.ts
+++ b/src/rest/reference/index.test.ts
@@ -1,8 +1,8 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-import * as fetch from "cross-fetch";
+import fetchModule from '../transport/fetch';
 
-import { referenceClient } from "./index";
+import { IReferenceClient, referenceClient } from "./index.js";
 
 describe("[REST] Reference", () => {
   chai.should();
@@ -21,12 +21,12 @@ describe("[REST] Reference", () => {
     }
   };
   let fetchStub;
-  let ref;
+  let ref: IReferenceClient;
   const sandbox = sinon.createSandbox();
   const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
   const setStub = (returnVal, status = 200) => {
     fetchStub?.restore();
-    fetchStub = sandbox.stub(fetch, "default").returns(
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
       Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
     );
     ref = referenceClient(mocks.key, mocks.base, mocks.globalOptions);

--- a/src/rest/reference/index.ts
+++ b/src/rest/reference/index.ts
@@ -1,4 +1,4 @@
-import { auth, IHeaders } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 import { IConditionsQuery, IConditions, conditions } from "./conditions";
 import { IExchangesQuery, IExchanges, exchanges } from "./exchanges";
@@ -35,46 +35,49 @@ export { ITickers, ITickersQuery } from "./tickers";
 export { ITickerTypes, ITickerTypesQuery } from "./tickerTypes";
 
 export interface IReferenceClient {
-  conditions: (query?: IConditionsQuery, headers?: IHeaders) => Promise<IConditions>;
-  exchanges: (query?: IExchangesQuery, headers?: IHeaders) => Promise<IExchanges>;
-  marketHolidays: (headers?: IHeaders) => Promise<IMarketHoliday[]>;
-  marketStatus: (headers?: IHeaders) => Promise<IMarketStatus>;
+  conditions: (query?: IConditionsQuery, options?: IRequestOptions) => Promise<IConditions>;
+  exchanges: (query?: IExchangesQuery, options?: IRequestOptions) => Promise<IExchanges>;
+  marketHolidays: (query?: IPolygonQuery, options?: IRequestOptions) => Promise<IMarketHoliday[]>;
+  marketStatus: (query?: IPolygonQuery, options?: IRequestOptions) => Promise<IMarketStatus>;
   optionsContract: (
     optionsTicker: string,
     query?: IOptionsContractQuery,
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IOptionsContract>;
   optionsContracts: (
     query?: IOptionsContractsQuery, 
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IOptionsContracts>;
-  dividends: (query?: IDividendsQuery, headers?: IHeaders) => Promise<IDividendsResults>;
-  stockSplits: (query?: IStockSplitsQuery, headers?: IHeaders) => Promise<IStockSplitsResults>;
-  stockFinancials: (query?: IStockFinancialQuery, headers?: IHeaders) => Promise<IStockFinancialResults>;
-  tickerDetails: (symbol: string, headers?: IHeaders) => Promise<ITickerDetails>;
-  tickerNews: (query?: ITickerNewsQuery, headers?: IHeaders) => Promise<ITickerNews>;
-  tickers: (query?: ITickersQuery, headers?: IHeaders) => Promise<ITickers>;
-  tickerTypes: (query?: ITickerTypesQuery, headers?: IHeaders) => Promise<ITickerTypes>;
+  dividends: (query?: IDividendsQuery, options?: IRequestOptions) => Promise<IDividendsResults>;
+  stockSplits: (query?: IStockSplitsQuery, options?: IRequestOptions) => Promise<IStockSplitsResults>;
+  stockFinancials: (query?: IStockFinancialQuery, options?: IRequestOptions) => Promise<IStockFinancialResults>;
+  tickerDetails: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ITickerDetails>;
+  tickerNews: (query?: ITickerNewsQuery, options?: IRequestOptions) => Promise<ITickerNews>;
+  tickers: (query?: ITickersQuery, options?: IRequestOptions) => Promise<ITickers>;
+  tickerTypes: (query?: ITickerTypesQuery, options?: IRequestOptions) => Promise<ITickerTypes>;
 }
 
 export const referenceClient = (
   apiKey: string,
   apiBase = "https://api.polygon.io",
-  headers?: IHeaders
-): IReferenceClient => ({
-  conditions: auth(apiKey, conditions, apiBase, headers),
-  exchanges: auth(apiKey, exchanges, apiBase, headers),
-  marketHolidays: auth(apiKey, marketHolidays, apiBase, headers),
-  marketStatus: auth(apiKey, marketStatus, apiBase, headers),
-  optionsContract: auth(apiKey, optionsContract, apiBase, headers),
-  optionsContracts: auth(apiKey, optionsContracts, apiBase, headers),
-  dividends: auth(apiKey, stockDividends, apiBase, headers),
-  stockSplits: auth(apiKey, stockSplits, apiBase, headers),
-  stockFinancials: auth(apiKey, stockFinancials, apiBase, headers),
-  tickerDetails: auth(apiKey, tickerDetails, apiBase, headers),
-  tickerNews: auth(apiKey, tickerNews, apiBase, headers),
-  tickers: auth(apiKey, tickers, apiBase, headers),
-  tickerTypes: auth(apiKey, tickerTypes, apiBase, headers),
-});
-
+  options?: IRequestOptions
+): IReferenceClient => {
+const get = getWithGlobals(apiKey, apiBase, options);
+    
+  return ({
+    conditions: (...args) => conditions(get, ...args),
+    exchanges: (...args) => exchanges(get, ...args),
+    marketHolidays: (...args) => marketHolidays(get, ...args),
+    marketStatus: (...args) => marketStatus(get, ...args),
+    optionsContract: (...args) => optionsContract(get, ...args),
+    optionsContracts: (...args) => optionsContracts(get, ...args),
+    dividends: (...args) => stockDividends(get, ...args),
+    stockSplits: (...args) => stockSplits(get, ...args),
+    stockFinancials: (...args) => stockFinancials(get, ...args),
+    tickerDetails: (...args) => tickerDetails(get, ...args),
+    tickerNews: (...args) => tickerNews(get, ...args),
+    tickers: (...args) => tickers(get, ...args),
+    tickerTypes: (...args) => tickerTypes(get, ...args),
+  });
+}
 export default referenceClient;

--- a/src/rest/reference/index.ts
+++ b/src/rest/reference/index.ts
@@ -1,38 +1,38 @@
-import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
-import { IConditionsQuery, IConditions, conditions } from "./conditions";
-import { IExchangesQuery, IExchanges, exchanges } from "./exchanges";
-import { IMarketHoliday, marketHolidays } from "./marketHolidays";
-import { IMarketStatus, marketStatus } from "./marketStatus";
+import { IConditionsQuery, IConditions, conditions } from "./conditions.js";
+import { IExchangesQuery, IExchanges, exchanges } from "./exchanges.js";
+import { IMarketHoliday, marketHolidays } from "./marketHolidays.js";
+import { IMarketStatus, marketStatus } from "./marketStatus.js";
 import {
   IOptionsContractQuery,
   IOptionsContract,
   optionsContract,
-} from "./optionsContract";
+} from "./optionsContract.js";
 import {
   IOptionsContractsQuery,
   IOptionsContracts,
   optionsContracts,
-} from "./optionsContracts";
-import { IDividendsResults, IDividendsQuery, stockDividends } from "./dividends";
-import { IStockSplitsResults, IStockSplitsQuery, stockSplits } from "./stockSplits";
-import { IStockFinancialResults, IStockFinancialQuery, stockFinancials } from "./stockFinancials";
-import { ITickerDetails, tickerDetails } from "./tickerDetails";
-import { ITickerNews, ITickerNewsQuery, tickerNews } from "./tickerNews";
-import { ITickers, ITickersQuery, tickers } from "./tickers";
-import { ITickerTypes, ITickerTypesQuery, tickerTypes } from "./tickerTypes";
+} from "./optionsContracts.js";
+import { IDividendsResults, IDividendsQuery, stockDividends } from "./dividends.js";
+import { IStockSplitsResults, IStockSplitsQuery, stockSplits } from "./stockSplits.js";
+import { IStockFinancialResults, IStockFinancialQuery, stockFinancials } from "./stockFinancials.js";
+import { ITickerDetails, tickerDetails } from "./tickerDetails.js";
+import { ITickerNews, ITickerNewsQuery, tickerNews } from "./tickerNews.js";
+import { ITickers, ITickersQuery, tickers } from "./tickers.js";
+import { ITickerTypes, ITickerTypesQuery, tickerTypes } from "./tickerTypes.js";
 
-export { IConditions } from "./conditions";
-export { IExchanges } from "./exchanges";
-export { IMarketHoliday } from "./marketHolidays";
-export { IMarketStatus } from "./marketStatus";
-export { IDividendsResults } from "./dividends";
-export { IStockSplitsResults } from "./stockSplits";
-export { IStockFinancialResults } from "./stockFinancials";
-export { ITickerDetails } from "./tickerDetails";
-export { ITickerNews, ITickerNewsQuery } from "./tickerNews";
-export { ITickers, ITickersQuery } from "./tickers";
-export { ITickerTypes, ITickerTypesQuery } from "./tickerTypes";
+export { IConditions } from "./conditions.js";
+export { IExchanges } from "./exchanges.js";
+export { IMarketHoliday } from "./marketHolidays.js";
+export { IMarketStatus } from "./marketStatus.js";
+export { IDividendsResults } from "./dividends.js";
+export { IStockSplitsResults } from "./stockSplits.js";
+export { IStockFinancialResults } from "./stockFinancials.js";
+export { ITickerDetails } from "./tickerDetails.js";
+export { ITickerNews, ITickerNewsQuery } from "./tickerNews.js";
+export { ITickers, ITickersQuery } from "./tickers.js";
+export { ITickerTypes, ITickerTypesQuery } from "./tickerTypes.js";
 
 export interface IReferenceClient {
   conditions: (query?: IConditionsQuery, options?: IRequestOptions) => Promise<IConditions>;

--- a/src/rest/reference/marketHolidays.ts
+++ b/src/rest/reference/marketHolidays.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IMarketHoliday {
   close?: string;

--- a/src/rest/reference/marketHolidays.ts
+++ b/src/rest/reference/marketHolidays.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IMarketHoliday {
   close?: string;
@@ -12,8 +12,8 @@ export interface IMarketHoliday {
 }
 
 export const marketHolidays = async (
-  apiKey: string,
-  apiBase: string,
-  headers?: IHeaders
+  get: IGet,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<IMarketHoliday[]> =>
-  get("/v1/marketstatus/upcoming", apiKey, apiBase, {}, headers);
+  get("/v1/marketstatus/upcoming", query, options);

--- a/src/rest/reference/marketStatus.ts
+++ b/src/rest/reference/marketStatus.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_marketstatus_now
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IMarketStatus {
   afterhours?: boolean;
@@ -19,7 +19,7 @@ export interface IMarketStatus {
 }
 
 export const marketStatus = async (
-  apiKey: string,
-  apiBase: string,
-  headers?: IHeaders
-): Promise<IMarketStatus> => get("/v1/marketstatus/now", apiKey, apiBase, {}, headers);
+  get: IGet,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
+): Promise<IMarketStatus> => get("/v1/marketstatus/now", query, options);

--- a/src/rest/reference/marketStatus.ts
+++ b/src/rest/reference/marketStatus.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_marketstatus_now
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IMarketStatus {
   afterhours?: boolean;

--- a/src/rest/reference/optionsContract.ts
+++ b/src/rest/reference/optionsContract.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IOptionsContractQuery extends IPolygonQuery {
   as_of?: string;

--- a/src/rest/reference/optionsContract.ts
+++ b/src/rest/reference/optionsContract.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IOptionsContractQuery extends IPolygonQuery {
   as_of?: string;
@@ -33,16 +33,13 @@ export interface IOptionsContract {
 }
 
 export const optionsContract = (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   optionsTicker: string,
   query?: IOptionsContractQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IOptionsContract> =>
   get(
     `/v3/reference/options/contracts/${optionsTicker}`,
-    apiKey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/reference/optionsContracts.ts
+++ b/src/rest/reference/optionsContracts.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_reference_options_contracts
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IOptionsContractsQuery extends IPolygonQuery {
   ticker?: string;

--- a/src/rest/reference/optionsContracts.ts
+++ b/src/rest/reference/optionsContracts.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/options/get_v3_reference_options_contracts
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IOptionsContractsQuery extends IPolygonQuery {
   ticker?: string;
@@ -38,9 +38,8 @@ export interface IOptionsContracts {
 }
 
 export const optionsContracts = (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IOptionsContractsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IOptionsContracts> =>
-  get("/v3/reference/options/contracts", apiKey, apiBase, query, headers);
+  get("/v3/reference/options/contracts", query, options);

--- a/src/rest/reference/stockFinancials.ts
+++ b/src/rest/reference/stockFinancials.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_vx_reference_financials
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface ITableInfo {
   formula?: string;
@@ -70,9 +70,8 @@ export interface IStockFinancialQuery extends IPolygonQuery {
 }
 
 export const stockFinancials = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IStockFinancialQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IStockFinancialResults> =>
-  get(`/vX/reference/financials`, apiKey, apiBase, query, headers);
+  get(`/vX/reference/financials`, query, options);

--- a/src/rest/reference/stockFinancials.ts
+++ b/src/rest/reference/stockFinancials.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_vx_reference_financials
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface ITableInfo {
   formula?: string;

--- a/src/rest/reference/stockSplits.ts
+++ b/src/rest/reference/stockSplits.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_splits__stocksTicker
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IStockSplit {
   execution_date?: string;
@@ -34,9 +34,8 @@ export interface IStockSplitsQuery extends IPolygonQuery {
 }
 
 export const stockSplits = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: IStockSplitsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IStockSplitsResults> =>
-  get(`/v3/reference/splits`, apiKey, apiBase, query, headers);
+  get(`/v3/reference/splits`, query, options);

--- a/src/rest/reference/stockSplits.ts
+++ b/src/rest/reference/stockSplits.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_splits__stocksTicker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IStockSplit {
   execution_date?: string;

--- a/src/rest/reference/tickerDetails.ts
+++ b/src/rest/reference/tickerDetails.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface ITickerDetails {
   request_id?: string;

--- a/src/rest/reference/tickerDetails.ts
+++ b/src/rest/reference/tickerDetails.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
 
-import { get, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface ITickerDetails {
   request_id?: string;
@@ -40,9 +40,9 @@ export interface ITickerDetails {
 }
 
 export const tickerDetails = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
-  headers?: IHeaders
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ITickerDetails> =>
-  get(`/v3/reference/tickers/${symbol}`, apiKey, apiBase, {},  headers);
+  get(`/v3/reference/tickers/${symbol}`, query, options);

--- a/src/rest/reference/tickerNews.ts
+++ b/src/rest/reference/tickerNews.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_news
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 import { Order } from "./tickers";
 
 export type Publisher = {

--- a/src/rest/reference/tickerNews.ts
+++ b/src/rest/reference/tickerNews.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_reference_news
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 import { Order } from "./tickers";
 
 export type Publisher = {
@@ -46,8 +46,7 @@ export interface ITickerNews {
 }
 
 export const tickerNews = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: ITickerNewsQuery,
-  headers?: IHeaders
-): Promise<ITickerNews> => get(`/v2/reference/news`, apiKey, apiBase, query, headers);
+  options?: IRequestOptions
+): Promise<ITickerNews> => get(`/v2/reference/news`, query, options);

--- a/src/rest/reference/tickerTypes.ts
+++ b/src/rest/reference/tickerTypes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers_types
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export type AssetClassType = "stocks" | "options" | "crypto" | "fx";
 export type LocaleType = "us" | "global";

--- a/src/rest/reference/tickerTypes.ts
+++ b/src/rest/reference/tickerTypes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers_types
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export type AssetClassType = "stocks" | "options" | "crypto" | "fx";
 export type LocaleType = "us" | "global";
@@ -25,9 +25,8 @@ export interface ITickerTypes {
 }
 
 export const tickerTypes = async (
-  apiKeys: string,
-  apiBase: string,
+  get: IGet,
   query?: ITickerTypesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<ITickerTypes> =>
-  get("/v3/reference/tickers/types", apiKeys, apiBase, query, headers);
+  get("/v3/reference/tickers/types", query, options);

--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export type TickerTypes =
   | "CS"

--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_reference_tickers
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export type TickerTypes =
   | "CS"
@@ -68,8 +68,7 @@ export interface ITickers {
 }
 
 export const tickers = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   query?: ITickersQuery,
-  headers?: IHeaders
-): Promise<ITickers> => get("/v3/reference/tickers", apiKey, apiBase, query, headers);
+  options?: IRequestOptions
+): Promise<ITickers> => get("/v3/reference/tickers", query, options);

--- a/src/rest/stocks/aggregates.ts
+++ b/src/rest/stocks/aggregates.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksTicker__range__multiplier___timespan___from___to
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IAggsResults {
   T?: string;

--- a/src/rest/stocks/aggregates.ts
+++ b/src/rest/stocks/aggregates.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksTicker__range__multiplier___timespan___from___to
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IAggsResults {
   T?: string;
@@ -31,20 +31,17 @@ export interface IAggs {
 }
 
 export const aggregates = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   ticker: string,
   multiplier: number,
   timespan: string,
   from: string | number,
   to: string | number,
   query?: IAggsQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<IAggs> =>
   get(
     `/v2/aggs/ticker/${ticker}/range/${multiplier}/${timespan}/${from}/${to}`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/stocks/aggregatesGroupedDaily.ts
+++ b/src/rest/stocks/aggregatesGroupedDaily.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
-import { IAggsResults } from "./aggregates";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
+import { IAggsResults } from "./aggregates.js";
 
 export interface IAggsGroupedDailyQuery extends IPolygonQuery {
   adjusted?: "true" | "false";

--- a/src/rest/stocks/aggregatesGroupedDaily.ts
+++ b/src/rest/stocks/aggregatesGroupedDaily.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 import { IAggsResults } from "./aggregates";
 
 export interface IAggsGroupedDailyQuery extends IPolygonQuery {
@@ -16,14 +16,13 @@ export interface IAggsGroupedDaily {
 }
 
 export const aggregatesGroupedDaily = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   date: string,
-  query?: IAggsGroupedDailyQuery
+  query?: IAggsGroupedDailyQuery,
+  options?: IRequestOptions
 ): Promise<IAggsGroupedDaily> =>
   get(
     `/v2/aggs/grouped/locale/us/market/stocks/${date}`,
-    apiKey,
-    apiBase,
-    query
+    query,
+    options
   );

--- a/src/rest/stocks/dailyOpenClose.ts
+++ b/src/rest/stocks/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface IDailyOpenCloseQuery extends IPolygonQuery {
   adjusted?: "true" | "false";
@@ -20,10 +20,10 @@ export interface IDailyOpenClose {
 }
 
 export const dailyOpenClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
   date: string,
-  query?: IDailyOpenCloseQuery
+  query?: IDailyOpenCloseQuery,
+  options?: IRequestOptions
 ): Promise<IDailyOpenClose> =>
-  get(`/v1/open-close/${symbol}/${date}`, apiKey, apiBase, query);
+  get(`/v1/open-close/${symbol}/${date}`, query, options);

--- a/src/rest/stocks/dailyOpenClose.ts
+++ b/src/rest/stocks/dailyOpenClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface IDailyOpenCloseQuery extends IPolygonQuery {
   adjusted?: "true" | "false";

--- a/src/rest/stocks/ema.ts
+++ b/src/rest/stocks/ema.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_ema__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export interface IEmaResults {
     underlying?: IUnderyling;

--- a/src/rest/stocks/ema.ts
+++ b/src/rest/stocks/ema.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_ema__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export interface IEmaResults {
     underlying?: IUnderyling;
@@ -16,8 +16,8 @@ export interface IEma {
 };
 
 export const ema = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IEma> => get(`/v1/indicators/ema/${symbol}`, query, options);

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -1,8 +1,8 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
-import * as fetch from "cross-fetch";
+import fetchModule from '../transport/fetch';
 
-import { stocksClient } from "./index";
+import { IStocksClient, stocksClient } from "./index.js";
 
 describe("[REST] Stocks", () => {
   chai.should();
@@ -21,12 +21,12 @@ describe("[REST] Stocks", () => {
     }
   };
   let fetchStub;
-  let stocks;
+  let stocks: IStocksClient;
   const sandbox = sinon.createSandbox();
   const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
   const setStub = (returnVal, status = 200) => {
     fetchStub?.restore();
-    fetchStub = sandbox.stub(fetch, "default").returns(
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
       Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
     );
     stocks = stocksClient(mocks.key, mocks.base, mocks.globalOptions);

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -192,6 +192,20 @@ describe("[REST] Stocks", () => {
     await stocks.trades("AAPL", mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
-    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].headers.Authorization.should.eql(`Bearer ${mocks.key}`);
+  });
+  
+  it("global options are applied if query is not passed in", async () => {
+    await stocks.trades("AAPL");
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.globalOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("all options are applied if query is undefined", async () => {
+    await stocks.trades("AAPL", undefined, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 });

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -1,150 +1,197 @@
 import * as sinon from "sinon";
 import * as chai from "chai";
+import * as fetch from "cross-fetch";
 
-import * as request from "../transport/request";
 import { stocksClient } from "./index";
 
 describe("[REST] Stocks", () => {
   chai.should();
-  let requestStub;
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  let stocks;
   const sandbox = sinon.createSandbox();
-  const stocks = stocksClient("invalid");
-  beforeEach(() => {
-    requestStub = sandbox
-      .stub(request, "get")
-      .returns(Promise.resolve({ ticks: [], results: [], tickers: [] }));
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetch, "default").returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+    stocks = stocksClient(mocks.key, mocks.base, mocks.globalOptions);
+  }
+  beforeEach(async () => {
+    setStub({ ticks: [], results: [], tickers: [] });
   });
   afterEach(() => {
     sandbox.restore();
   });
 
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
     );
-    await stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("aggregatesGroupedDaily call /v2/aggs/grouped/locale/us/market/stocks/{date}", async () => {
-    requestStub.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        results: [],
-      })
+    setStub({ results: [] });
+    await stocks.aggregatesGroupedDaily("2019-02-01", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/grouped/locale/us/market/stocks/2019-02-01"
     );
-    await stocks.aggregatesGroupedDaily("2019-02-01");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql(
-        "/v2/aggs/grouped/locale/us/market/stocks/2019-02-01"
-      );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("dailyOpenClose call /v1/open-close/{symbol}/{date}", async () => {
-    await stocks.dailyOpenClose("AAPL", "2018-2-2");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v1/open-close/AAPL/2018-2-2");
+    await stocks.dailyOpenClose("AAPL", "2018-2-2", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/open-close/AAPL/2018-2-2");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("last quote call /v2/last/nbbo/{stocksTicker}", async () => {
-    await stocks.lastQuote("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/last/nbbo/AAPL");
+    await stocks.lastQuote("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/last/nbbo/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("last trade call /v2/last/trade/{stocksTicker}", async () => {
-    await stocks.lastTrade("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/last/trade/AAPL");
+    await stocks.lastTrade("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/last/trade/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("previous close call /v2/aggs/ticker/{stocksTicker}/prev", async () => {
-    await stocks.previousClose("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v2/aggs/ticker/AAPL/prev");
+    await stocks.previousClose("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/aggs/ticker/AAPL/prev");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("quotes call /v3/quotes/{stockTicker}  ", async () => {
-    await stocks.quotes("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/quotes/AAPL");
+    await stocks.quotes("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/quotes/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - all tickers call /v2/snapshot/locale/us/markets/stocks/tickers", async () => {
-    await stocks.snapshotAllTickers();
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/us/markets/stocks/tickers");
+    await stocks.snapshotAllTickers(mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/us/markets/stocks/tickers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot - gainers / losers call /v2/snapshot/locale/us/markets/stocks/{direction}", async () => {
-    await stocks.snapshotGainersLosers("gainers");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/us/markets/stocks/gainers");
+    await stocks.snapshotGainersLosers("gainers", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/us/markets/stocks/gainers");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("snapshot ticker call /v2/snapshot/locale/us/markets/stocks/tickers/{ticker}", async () => {
-    sandbox.restore();
-    requestStub = sandbox.stub(request, "get").returns(
-      Promise.resolve({
-        ticker: {
-          day: {},
-          lastTrade: {},
-          lastQuote: {},
-          min: {},
-          prevDay: {},
-        },
-      })
-    );
-    await stocks.snapshotTicker("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub
-      .getCalls()[0]
-      .args[0].should.eql("/v2/snapshot/locale/us/markets/stocks/tickers/AAPL");
+    setStub({
+      ticker: {
+        day: {},
+        lastTrade: {},
+        lastQuote: {},
+        min: {},
+        prevDay: {},
+      },
+    });
+    await stocks.snapshotTicker("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v2/snapshot/locale/us/markets/stocks/tickers/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("sma call /v1/indicators/sma/{stockTicker}", async () => {
-    await stocks.sma("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/sma/AAPL");
+    await stocks.sma("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/sma/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("ema call /v1/indicators/ema/{stockTicker}", async () => {
-    await stocks.ema("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/ema/AAPL");
+    await stocks.ema("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/ema/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("macd call /v1/indicators/macd/{stockTicker}", async () => {
-    await stocks.macd("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/macd/AAPL");
+    await stocks.macd("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/macd/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("rsi call /v1/indicators/rsi/{stockTicker}", async () => {
-    await stocks.rsi("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v1/indicators/rsi/AAPL");
+    await stocks.rsi("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v1/indicators/rsi/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
   it("trades call /v3/trades/{stockTicker}", async () => {
-    await stocks.trades("AAPL");
-    requestStub.callCount.should.eql(1);
-    requestStub.getCalls()[0].args[0].should.eql("/v3/trades/AAPL");
+    await stocks.trades("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql("/v3/trades/AAPL");
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+  it("apiKey and apiBase are passed", async () => {
+    await stocks.trades("AAPL", mocks.query, mocks.overrideOptions);
+    fetchStub.callCount.should.eql(1);
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.base).should.eql(0);
+    fetchStub.getCalls()[0].args[0].indexOf(`apiKey=${mocks.key}`).should.be.gt(-1);
   });
 });

--- a/src/rest/stocks/index.ts
+++ b/src/rest/stocks/index.ts
@@ -1,23 +1,23 @@
-import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
-import { IAggsQuery, IAggs, aggregates } from "./aggregates";
+import { IAggsQuery, IAggs, aggregates } from "./aggregates.js";
 import {
   IAggsGroupedDailyQuery,
   IAggsGroupedDaily,
   aggregatesGroupedDaily,
-} from "./aggregatesGroupedDaily";
+} from "./aggregatesGroupedDaily.js";
 import {
   IDailyOpenCloseQuery,
   IDailyOpenClose,
   dailyOpenClose,
-} from "./dailyOpenClose";
+} from "./dailyOpenClose.js";
 import {
   IAggsPreviousCloseQuery,
   IAggsPreviousClose,
   previousClose,
-} from "./previousClose";
-import { ILastQuote, lastQuote } from "./lastQuote";
-import { ILastTrade, lastTrade } from "./lastTrade";
+} from "./previousClose.js";
+import { ILastQuote, lastQuote } from "./lastQuote.js";
+import { ILastTrade, lastTrade } from "./lastTrade.js";
 import {
   ISnapshotAllTickersQuery,
   ISnapshotTickers,
@@ -25,36 +25,36 @@ import {
   snapshotAllTickers,
   snapshotGainersLosers,
   snapshotTicker,
-} from "./snapshots";
-import { IQuotes, quotes } from "./quotes";
-import { ITradesQuotesQuery, ITrades, trades } from "./trades";
-import { ISummaries, ISummariesQuery, summaries } from "./summaries";
-import { ISma, ITechnicalIndicatorsQuery, sma } from "./sma";
-import { IEma, ema } from "./ema";
-import { IMacd, macd } from "./macd";
-import { IRsi, rsi } from "./rsi";
+} from "./snapshots.js";
+import { IQuotes, quotes } from "./quotes.js";
+import { ITradesQuotesQuery, ITrades, trades } from "./trades.js";
+import { ISummaries, ISummariesQuery, summaries } from "./summaries.js";
+import { ISma, ITechnicalIndicatorsQuery, sma } from "./sma.js";
+import { IEma, ema } from "./ema.js";
+import { IMacd, macd } from "./macd.js";
+import { IRsi, rsi } from "./rsi.js";
 
-export { IAggsQuery, IAggs } from "./aggregates";
+export { IAggsQuery, IAggs } from "./aggregates.js";
 export {
   IAggsGroupedDailyQuery,
   IAggsGroupedDaily,
-} from "./aggregatesGroupedDaily";
-export { IDailyOpenCloseQuery, IDailyOpenClose } from "./dailyOpenClose";
-export { IAggsPreviousCloseQuery, IAggsPreviousClose } from "./previousClose";
-export { ILastQuote } from "./lastQuote";
-export { ILastTrade } from "./lastTrade";
+} from "./aggregatesGroupedDaily.js";
+export { IDailyOpenCloseQuery, IDailyOpenClose } from "./dailyOpenClose.js";
+export { IAggsPreviousCloseQuery, IAggsPreviousClose } from "./previousClose.js";
+export { ILastQuote } from "./lastQuote.js";
+export { ILastTrade } from "./lastTrade.js";
 export {
   ISnapshotAllTickersQuery,
   ISnapshotTickers,
   ISnapshot,
-} from "./snapshots";
-export { IQuotes } from "./quotes";
-export { ITradesQuotesQuery, ITrades } from "./trades";
-export { ISummariesQuery, ISummaries } from './summaries';
-export { ISma, ITechnicalIndicatorsQuery } from './sma';
-export { IEma } from './ema';
-export { IMacd } from './macd';
-export { IRsi } from './rsi';
+} from "./snapshots.js";
+export { IQuotes } from "./quotes.js";
+export { ITradesQuotesQuery, ITrades } from "./trades.js";
+export { ISummariesQuery, ISummaries } from './summaries.js';
+export { ISma, ITechnicalIndicatorsQuery } from './sma.js';
+export { IEma } from './ema.js';
+export { IMacd } from './macd.js';
+export { IRsi } from './rsi.js';
 
 export interface IStocksClient {
   aggregates: (

--- a/src/rest/stocks/index.ts
+++ b/src/rest/stocks/index.ts
@@ -1,4 +1,4 @@
-import { auth, IHeaders } from "../transport/request";
+import { getWithGlobals, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 import { IAggsQuery, IAggs, aggregates } from "./aggregates";
 import {
@@ -64,60 +64,70 @@ export interface IStocksClient {
     from: string,
     to: string,
     query?: IAggsQuery,
-    headers?: IHeaders
+    options?: IRequestOptions
   ) => Promise<IAggs>;
   aggregatesGroupedDaily: (
     date: string,
-    query?: IAggsGroupedDailyQuery
+    query?: IAggsGroupedDailyQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsGroupedDaily>;
-  summaries: (query?: ISummariesQuery, headers?: IHeaders) => Promise<ISummaries>;
+  summaries: (query?: ISummariesQuery, options?: IRequestOptions) => Promise<ISummaries>;
   dailyOpenClose: (
     symbol: string,
     date: string,
-    query?: IDailyOpenCloseQuery
+    query?: IDailyOpenCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IDailyOpenClose>;
-  lastQuote: (symbol: string) => Promise<ILastQuote>;
-  lastTrade: (symbol: string) => Promise<ILastTrade>;
+  lastQuote: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ILastQuote>;
+  lastTrade: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ILastTrade>;
   previousClose: (
     ticker: string,
-    query?: IAggsPreviousCloseQuery
+    query?: IAggsPreviousCloseQuery,
+    options?: IRequestOptions
   ) => Promise<IAggsPreviousClose>;
-  quotes: (stockTicker: string, query?: ITradesQuotesQuery) => Promise<IQuotes>;
+  quotes: (stockTicker: string, query?: ITradesQuotesQuery, options?: IRequestOptions) => Promise<IQuotes>;
   snapshotAllTickers: (
-    query?: ISnapshotAllTickersQuery
+    query?: ISnapshotAllTickersQuery,
+    options?: IRequestOptions
   ) => Promise<ISnapshotTickers>;
   snapshotGainersLosers: (
-    direction: "gainers" | "losers"
+    direction: "gainers" | "losers",
+    query?: IPolygonQuery,
+    options?: IRequestOptions
   ) => Promise<ISnapshotTickers>;
-  snapshotTicker: (symbol: string) => Promise<ISnapshot>;
-  sma: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<ISma>;
-  ema: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IEma>;
-  macd: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IMacd>;
-  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery) => Promise<IRsi>;
-  trades: (stockTicker: string, query?: ITradesQuotesQuery) => Promise<ITrades>;
+  snapshotTicker: (symbol: string, query?: IPolygonQuery, options?: IRequestOptions) => Promise<ISnapshot>;
+  sma: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<ISma>;
+  ema: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IEma>;
+  macd: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IMacd>;
+  rsi: (symbol: string, query?: ITechnicalIndicatorsQuery, options?: IRequestOptions) => Promise<IRsi>;
+  trades: (stockTicker: string, query?: ITradesQuotesQuery, options?: IRequestOptions) => Promise<ITrades>;
 }
 
 export const stocksClient = (
   apiKey: string,
   apiBase = "https://api.polygon.io",
-  headers?: IHeaders
-): IStocksClient => ({
-  aggregates: auth(apiKey, aggregates, apiBase, headers),
-  aggregatesGroupedDaily: auth(apiKey, aggregatesGroupedDaily, apiBase),
-  summaries: auth(apiKey, summaries, apiBase, headers),
-  dailyOpenClose: auth(apiKey, dailyOpenClose, apiBase),
-  lastQuote: auth(apiKey, lastQuote, apiBase),
-  lastTrade: auth(apiKey, lastTrade, apiBase),
-  previousClose: auth(apiKey, previousClose, apiBase),
-  quotes: auth(apiKey, quotes, apiBase),
-  snapshotAllTickers: auth(apiKey, snapshotAllTickers, apiBase),
-  snapshotGainersLosers: auth(apiKey, snapshotGainersLosers, apiBase),
-  snapshotTicker: auth(apiKey, snapshotTicker, apiBase),
-  sma: auth(apiKey, sma, apiBase), 
-  ema: auth(apiKey, ema, apiBase), 
-  macd: auth(apiKey, macd, apiBase), 
-  rsi: auth(apiKey, rsi, apiBase), 
-  trades: auth(apiKey, trades, apiBase),
-});
+  options?: IRequestOptions
+): IStocksClient => {
+  const get = getWithGlobals(apiKey, apiBase, options);
+    
+  return ({
+    aggregates: (...args) => aggregates(get, ...args),
+    aggregatesGroupedDaily: (...args) => aggregatesGroupedDaily(get, ...args),
+    summaries: (...args) => summaries(get, ...args),
+    dailyOpenClose: (...args) => dailyOpenClose(get, ...args),
+    lastQuote: (...args) => lastQuote(get, ...args),
+    lastTrade: (...args) => lastTrade(get, ...args),
+    previousClose: (...args) => previousClose(get, ...args),
+    quotes: (...args) => quotes(get, ...args),
+    snapshotAllTickers: (...args) => snapshotAllTickers(get, ...args),
+    snapshotGainersLosers: (...args) => snapshotGainersLosers(get, ...args),
+    snapshotTicker: (...args) => snapshotTicker(get, ...args),
+    sma: (...args) => sma(get, ...args),
+    ema: (...args) => ema(get, ...args),
+    macd: (...args) => macd(get, ...args),
+    rsi: (...args) => rsi(get, ...args),
+    trades: (...args) => trades(get, ...args)
+  })
+}
 
 export default stocksClient;

--- a/src/rest/stocks/lastQuote.ts
+++ b/src/rest/stocks/lastQuote.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
 
-import { get } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 import { ILastTradeInfo } from "./lastTrade";
 
 export interface ILastQuote {
@@ -10,7 +10,8 @@ export interface ILastQuote {
 }
 
 export const lastQuote = async (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
-): Promise<ILastQuote> => get(`/v2/last/nbbo/${symbol}`, apiKey, apiBase);
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
+): Promise<ILastQuote> => get(`/v2/last/nbbo/${symbol}`, query, options);

--- a/src/rest/stocks/lastQuote.ts
+++ b/src/rest/stocks/lastQuote.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 import { ILastTradeInfo } from "./lastTrade";
 
 export interface ILastQuote {

--- a/src/rest/stocks/lastTrade.ts
+++ b/src/rest/stocks/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_last_trade__stocksTicker
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface ILastTradeInfo {
   T?: string;

--- a/src/rest/stocks/lastTrade.ts
+++ b/src/rest/stocks/lastTrade.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_last_trade__stocksTicker
 
-import { get } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface ILastTradeInfo {
   T?: string;
@@ -28,7 +28,8 @@ export interface ILastTrade {
 }
 
 export const lastTrade = async (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
-): Promise<ILastTrade> => get(`/v2/last/trade/${symbol}`, apiKey, apiBase);
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
+): Promise<ILastTrade> => get(`/v2/last/trade/${symbol}`, query, options);

--- a/src/rest/stocks/macd.ts
+++ b/src/rest/stocks/macd.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export interface IMacdResults {
     underlying?: IUnderyling;
@@ -16,8 +16,8 @@ export interface IMacd {
 };
 
 export const macd = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IMacd> => get(`/v1/indicators/macd/${symbol}`, query, options);

--- a/src/rest/stocks/macd.ts
+++ b/src/rest/stocks/macd.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export interface IMacdResults {
     underlying?: IUnderyling;

--- a/src/rest/stocks/previousClose.ts
+++ b/src/rest/stocks/previousClose.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksTicker__prev
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
-import { IAggsResults } from "./aggregates";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
+import { IAggsResults } from "./aggregates.js";
 
 export interface IAggsPreviousCloseQuery extends IPolygonQuery {
   adjusted?: "true" | "false";

--- a/src/rest/stocks/previousClose.ts
+++ b/src/rest/stocks/previousClose.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksTicker__prev
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 import { IAggsResults } from "./aggregates";
 
 export interface IAggsPreviousCloseQuery extends IPolygonQuery {
@@ -19,9 +19,9 @@ export interface IAggsPreviousClose {
 }
 
 export const previousClose = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   symbol: string,
-  query?: IAggsPreviousCloseQuery
+  query?: IAggsPreviousCloseQuery,
+  options?: IRequestOptions
 ): Promise<IAggsPreviousClose> =>
-  get(`/v2/aggs/ticker/${symbol}/prev`, apiKey, apiBase, query);
+  get(`/v2/aggs/ticker/${symbol}/prev`, query, options);

--- a/src/rest/stocks/quotes.ts
+++ b/src/rest/stocks/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_ticks_stocks_nbbo__ticker___date
 
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 import { ITradesQuotesQuery } from "./trades";
 
 export interface IQuotesInfo {

--- a/src/rest/stocks/quotes.ts
+++ b/src/rest/stocks/quotes.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v2_ticks_stocks_nbbo__ticker___date
 
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 import { ITradesQuotesQuery } from "./trades";
 
 export interface IQuotesInfo {
@@ -27,8 +27,8 @@ export interface IQuotes {
 }
 
 export const quotes = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   stockTicker: string,
-  query?: ITradesQuotesQuery
-): Promise<IQuotes> => get(`/v3/quotes/${stockTicker}`, apiKey, apiBase, query);
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
+): Promise<IQuotes> => get(`/v3/quotes/${stockTicker}`, query, options);

--- a/src/rest/stocks/rsi.ts
+++ b/src/rest/stocks/rsi.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { get } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request";
 
 export interface IRsiResults {
     underlying?: IUnderyling;
@@ -16,8 +16,8 @@ export interface IRsi {
 };
 
 export const rsi = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<IRsi> => get(`/v1/indicators/rsi/${symbol}`, query, options);

--- a/src/rest/stocks/rsi.ts
+++ b/src/rest/stocks/rsi.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 
 import { IUnderyling, IValue, ITechnicalIndicatorsQuery } from "./sma";
-import { IGet, IRequestOptions } from "../transport/request";
+import { IGet, IRequestOptions } from "../transport/request.js";
 
 export interface IRsiResults {
     underlying?: IUnderyling;

--- a/src/rest/stocks/sma.ts
+++ b/src/rest/stocks/sma.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_sma__stockticker
 
 import { IAggsResults } from "./aggregates";
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface IValue {
     histogram?: number;
@@ -46,8 +46,8 @@ export interface ISma {
 };
 
 export const sma = async (
-    apiKey: string,
-    apiBase: string,
+    get: IGet,
     symbol: string,
     query?: ITechnicalIndicatorsQuery,
-): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, apiKey, apiBase, query);
+    options?: IRequestOptions
+): Promise<ISma> => get(`/v1/indicators/sma/${symbol}`, query, options);

--- a/src/rest/stocks/sma.ts
+++ b/src/rest/stocks/sma.ts
@@ -1,7 +1,7 @@
 // CF: https://polygon.io/docs/stocks/get_v1_indicators_sma__stockticker
 
-import { IAggsResults } from "./aggregates";
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IAggsResults } from "./aggregates.js";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface IValue {
     histogram?: number;

--- a/src/rest/stocks/snapshots.ts
+++ b/src/rest/stocks/snapshots.ts
@@ -1,4 +1,4 @@
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface SnapshotDay {
   c?: number;
@@ -75,28 +75,30 @@ export interface ISnapshot {
 
 // CF: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers
 export const snapshotAllTickers = async (
-  apiKey: string,
-  apiBase: string,
-  query?: ISnapshotAllTickersQuery
+  get: IGet,
+  query?: ISnapshotAllTickersQuery,
+  options?: IRequestOptions
 ): Promise<ISnapshotTickers> =>
-  get(`/v2/snapshot/locale/us/markets/stocks/tickers`, apiKey, apiBase, query);
+  get(`/v2/snapshot/locale/us/markets/stocks/tickers`, query, options);
 
 // CF: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks__direction
 export const snapshotGainersLosers = async (
-  apiKey: string,
-  apiBase: string,
-  direction: "gainers" | "losers"
+  get: IGet,
+  direction: "gainers" | "losers",
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ISnapshotTickers> =>
-  get(`/v2/snapshot/locale/us/markets/stocks/${direction}`, apiKey, apiBase);
+  get(`/v2/snapshot/locale/us/markets/stocks/${direction}`, query, options);
 
 // CF: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers__stocksTicker
 export const snapshotTicker = async (
-  apiKey: string,
-  apiBase: string,
-  symbol: string
+  get: IGet,
+  symbol: string,
+  query?: IPolygonQuery,
+  options?: IRequestOptions
 ): Promise<ISnapshot> =>
   get(
     `/v2/snapshot/locale/us/markets/stocks/tickers/${symbol}`,
-    apiKey,
-    apiBase
+    query,
+    options
   );

--- a/src/rest/stocks/snapshots.ts
+++ b/src/rest/stocks/snapshots.ts
@@ -1,4 +1,4 @@
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface SnapshotDay {
   c?: number;

--- a/src/rest/stocks/summaries.ts
+++ b/src/rest/stocks/summaries.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/launchpad/get_v1_summaries
 
-import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 
 export interface IBranding {
     icon_url: string;

--- a/src/rest/stocks/summaries.ts
+++ b/src/rest/stocks/summaries.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/launchpad/get_v1_summaries
 
-import { get, IPolygonQuery, IHeaders } from "../transport/request";
+import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request";
 
 export interface IBranding {
     icon_url: string;
@@ -54,15 +54,12 @@ export interface ISummaries {
 }
 
 export const summaries = async (
-  apikey: string,
-  apiBase: string,
+  get: IGet,
   query?: ISummariesQuery,
-  headers?: IHeaders
+  options?: IRequestOptions
 ): Promise<ISummaries> =>
   get(
     `/v1/summaries`,
-    apikey,
-    apiBase,
     query,
-    headers
+    options
   );

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_trades__stockticker
 
-import { get, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
 
 export interface ITradeInfo {
   conditions: number[];
@@ -36,8 +36,8 @@ export interface ITrades {
 }
 
 export const trades = async (
-  apiKey: string,
-  apiBase: string,
+  get: IGet,
   stockTicker: string,
-  query?: ITradesQuotesQuery
-): Promise<ITrades> => get(`/v3/trades/${stockTicker}`, apiKey, apiBase, query);
+  query?: ITradesQuotesQuery,
+  options?: IRequestOptions
+): Promise<ITrades> => get(`/v3/trades/${stockTicker}`, query, options);

--- a/src/rest/stocks/trades.ts
+++ b/src/rest/stocks/trades.ts
@@ -1,6 +1,6 @@
 // CF: https://polygon.io/docs/stocks/get_v3_trades__stockticker
 
-import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request";
+import { IGet, IRequestOptions, IPolygonQuery } from "../transport/request.js";
 
 export interface ITradeInfo {
   conditions: number[];

--- a/src/rest/transport/fetch.ts
+++ b/src/rest/transport/fetch.ts
@@ -1,0 +1,6 @@
+import fetch from "cross-fetch";
+
+// es module named exports aren't mutable, so stubbing fetch for the tests wouldn't work with es modules.
+// Adding this layer with fetch exported as an object key lets us stub it in tests
+
+export default { fetch: (input, init) => fetch(input, init) };

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -1,4 +1,4 @@
-import fetch from "cross-fetch";
+import fetchModule from './fetch.js';
 import { stringify } from "query-string";
 
 export interface IPolygonQuery {
@@ -34,7 +34,7 @@ export const getWithGlobals: ICurriedGet = (apiKey, apiBase, globalOptions = {})
 
   const queryString = stringify(query, { encode: true });
   const url = `${apiBase}${path}?${queryString}`;
-  const response = await fetch(url, {
+  const response = await fetchModule.fetch(url, {
     ...globalOptions,
     ...options,
     headers: {

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -32,18 +32,15 @@ export const getWithGlobals: ICurriedGet = (apiKey, apiBase, globalOptions = {})
     throw new Error("API KEY not configured...");
   }
 
-  const authenticatedQuery: IPolygonQueryWithCredentials = {
-    ...query,
-    apiKey,
-  };
-
-  const queryString = stringify(authenticatedQuery, { encode: true });
-
+  const queryString = stringify(query, { encode: true });
   const url = `${apiBase}${path}?${queryString}`;
-
   const response = await fetch(url, {
     ...globalOptions,
-    ...options
+    ...options,
+    headers: {
+      ...(options.headers || globalOptions.headers || {}),
+      "Authorization": `Bearer ${apiKey}`
+    }
   });
 
   if (response.status >= 400) {

--- a/src/websockets/crypto/index.ts
+++ b/src/websockets/crypto/index.ts
@@ -1,5 +1,5 @@
-import { w3cwebsocket as Websocket } from "websocket";
-import { getWsClient } from "../transport";
+import * as websocket from "websocket";
+import { getWsClient } from "../transport/index.js";
 
 // Crypto AGGREGATE:
 export interface IAggregateCryptoEvent {
@@ -54,4 +54,4 @@ export interface ILevel2CryptoEvent {
 export const getCryptoWebsocket = (
   apiKey: string,
   apiBase = "wss://socket.polygon.io"
-): Websocket => getWsClient(`${apiBase}/crypto`, apiKey);
+): websocket.w3cwebsocket => getWsClient(`${apiBase}/crypto`, apiKey);

--- a/src/websockets/forex/index.ts
+++ b/src/websockets/forex/index.ts
@@ -1,5 +1,5 @@
-import { getWsClient } from "../transport";
-import { w3cwebsocket as Websocket } from "websocket";
+import { getWsClient } from "../transport/index.js";
+import * as websocket from "websocket";
 
 // Forex Aggregate:
 export interface IAggegateForexEvent {
@@ -26,4 +26,4 @@ export interface IQuoteForexEvent {
 export const getForexWebsocket = (
   apiKey: string,
   apiBase = "wss://socket.polygon.io"
-): Websocket => getWsClient(`${apiBase}/forex`, apiKey);
+): websocket.w3cwebsocket => getWsClient(`${apiBase}/forex`, apiKey);

--- a/src/websockets/index.ts
+++ b/src/websockets/index.ts
@@ -1,5 +1,4 @@
-import { auth } from "../rest/transport/request";
-
+import { w3cwebsocket as Websocket } from "websocket";
 import { getCryptoWebsocket } from "./crypto";
 import { getForexWebsocket } from "./forex";
 import { getOptionsWebsocket } from "./options";
@@ -10,20 +9,20 @@ export * from "./stocks";
 export * from "./crypto";
 
 export interface IWebsocketClient {
-  crypto: () => WebSocket;
-  forex: () => WebSocket;
-  options: () => WebSocket;
-  stocks: () => WebSocket;
+  crypto: () => Websocket;
+  forex: () => Websocket;
+  options: () => Websocket;
+  stocks: () => Websocket;
 }
 
 export const websocketClient = (
   apiKey: string,
   apiBase?: string
 ): IWebsocketClient => ({
-  crypto: auth(apiKey, getCryptoWebsocket, apiBase),
-  forex: auth(apiKey, getForexWebsocket, apiBase),
-  options: auth(apiKey, getOptionsWebsocket, apiBase),
-  stocks: auth(apiKey, getStocksWebsocket, apiBase),
+  crypto: () => getCryptoWebsocket(apiKey, apiBase),
+  forex: () => getForexWebsocket(apiKey, apiBase),
+  options: () => getOptionsWebsocket(apiKey, apiBase),
+  stocks: () => getStocksWebsocket(apiKey, apiBase),
 });
 
 export default websocketClient;

--- a/src/websockets/index.ts
+++ b/src/websockets/index.ts
@@ -1,18 +1,18 @@
-import { w3cwebsocket as Websocket } from "websocket";
-import { getCryptoWebsocket } from "./crypto";
-import { getForexWebsocket } from "./forex";
-import { getOptionsWebsocket } from "./options";
-import { getStocksWebsocket } from "./stocks";
+import * as websocket from "websocket";
+import { getCryptoWebsocket } from "./crypto/index.js";
+import { getForexWebsocket } from "./forex/index.js";
+import { getOptionsWebsocket } from "./options/index.js";
+import { getStocksWebsocket } from "./stocks/index.js";
 
-export * from "./forex";
-export * from "./stocks";
-export * from "./crypto";
+export * from "./forex/index.js";
+export * from "./stocks/index.js";
+export * from "./crypto/index.js";
 
 export interface IWebsocketClient {
-  crypto: () => Websocket;
-  forex: () => Websocket;
-  options: () => Websocket;
-  stocks: () => Websocket;
+  crypto: () => websocket.w3cwebsocket;
+  forex: () => websocket.w3cwebsocket;
+  options: () => websocket.w3cwebsocket;
+  stocks: () => websocket.w3cwebsocket;
 }
 
 export const websocketClient = (

--- a/src/websockets/options/index.ts
+++ b/src/websockets/options/index.ts
@@ -1,5 +1,5 @@
-import { getWsClient } from "../transport";
-import { w3cwebsocket as Websocket } from "websocket";
+import { getWsClient } from "../transport/index.js";
+import * as websocket from "websocket";
 
 // Options Aggregate:
 export interface IAggregateOptionsEvent {
@@ -32,4 +32,4 @@ export interface ITradeOptionsEvent {
 export const getOptionsWebsocket = (
   apiKey: string,
   apiBase = "wss://socket.polygon.io"
-): Websocket => getWsClient(`${apiBase}/options`, apiKey);
+): websocket.w3cwebsocket => getWsClient(`${apiBase}/options`, apiKey);

--- a/src/websockets/stocks/index.ts
+++ b/src/websockets/stocks/index.ts
@@ -1,5 +1,5 @@
-import { getWsClient } from "../transport";
-import { w3cwebsocket as Websocket } from "websocket";
+import { getWsClient } from "../transport/index.js";
+import * as websocket from "websocket";
 
 // Stocks Aggregate:
 export interface IAggregateStockEvent {
@@ -49,4 +49,4 @@ export interface IQuoteStockEvent {
 export const getStocksWebsocket = (
   apiKey: string,
   apiBase = "wss://socket.polygon.io"
-): Websocket => getWsClient(`${apiBase}/stocks`, apiKey);
+): websocket.w3cwebsocket => getWsClient(`${apiBase}/stocks`, apiKey);

--- a/src/websockets/transport/index.ts
+++ b/src/websockets/transport/index.ts
@@ -1,11 +1,10 @@
-import { w3cwebsocket as Websocket } from "websocket";
+import websocket from "websocket";
 
-export const getWsClient = (url: string, apiKey: string): Websocket => {
+export const getWsClient = (url: string, apiKey: string): websocket.w3cwebsocket => {
   if (!apiKey) {
     throw new Error("api key not provided.");
   }
-
-  const ws = new Websocket(url);
+  const ws = new websocket.w3cwebsocket(url);
 
   ws.onopen = () => {
     ws.send(JSON.stringify({ action: "auth", params: apiKey }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,10 @@
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "./src/**/*.test.ts"],
   "compilerOptions": {
-    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */,
+    "target": "es2021" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "module": "es2022" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "outDir": "lib" /* Redirect output structure to the directory. */,
     "typeRoots": [


### PR DESCRIPTION
User-facing Changes:
- Breaking change to replace headers parameter with a request options parameter (which includes headers)
- Added query object parameter and request options parameter to every endpoint
- Updated Launchpad header examples
- Added examples for advanced request configurations such as custom timeouts

Non User-facing Changes:
- Simplified code to avoid passing variables set on the client into each endpoint
- Added additional tests to make sure each endpoint implements query and request options
- Changed tests to mock and validate fetch instead of our wrapper method to ensure tests cover the whole stack

Implements feature request from issue #116 