### PR TITLE
Catch Rejected Promise and Throw Explicit Error

### DIFF
--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -207,4 +207,13 @@ describe("[REST] Crypto", () => {
     fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
     fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
+
+  it("properly handles promise rejections", async () => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
+    crypto = cryptoClient(mocks.key, mocks.base, mocks.globalOptions);
+    return crypto.summaries({ 'ticker.any_of': "X:BTCUSD,X:USDBTC" })
+        .then(function() { throw new Error('function should throw error'); })
+        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+  });
 });

--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -213,7 +213,7 @@ describe("[REST] Crypto", () => {
     fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
     crypto = cryptoClient(mocks.key, mocks.base, mocks.globalOptions);
     return crypto.summaries({ 'ticker.any_of': "X:BTCUSD,X:USDBTC" })
-        .then(function() { throw new Error('function should throw error'); })
-        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+      .then(() => { throw new Error('function should throw error'); })
+      .catch((e) => { chai.expect(e).to.be.an.instanceof (Error); })
   });
 });

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -196,4 +196,13 @@ describe("[REST] Forex / Currencies", () => {
     fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
 
+  it("properly handles promise rejections", async () => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
+    fx = forexClient(mocks.key, mocks.base, mocks.globalOptions);
+    return fx.summaries({ 'ticker.any_of': "C:USDEUR,C:EURAUD" })
+        .then(function() { throw new Error('function should throw error'); })
+        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+  });
+
 });

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -201,8 +201,8 @@ describe("[REST] Forex / Currencies", () => {
     fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
     fx = forexClient(mocks.key, mocks.base, mocks.globalOptions);
     return fx.summaries({ 'ticker.any_of': "C:USDEUR,C:EURAUD" })
-        .then(function() { throw new Error('function should throw error'); })
-        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+      .then(() => { throw new Error('function should throw error'); })
+      .catch((e) => { chai.expect(e).to.be.an.instanceof (Error); })
   });
 
 });

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -175,7 +175,7 @@ describe("[REST] Options", () => {
     fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
     options = optionsClient(mocks.key, mocks.base, mocks.globalOptions);
     return options.summaries({ 'ticker.any_of': "O:Ticker1,O:Ticker2" })
-        .then(function() { throw new Error('function should throw error'); })
-        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+      .then(() => { throw new Error('function should throw error'); })
+      .catch((e) => { chai.expect(e).to.be.an.instanceof (Error); })
   });
 });

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -169,4 +169,13 @@ describe("[REST] Options", () => {
     fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
     fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
+
+  it("properly handles promise rejections", async () => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
+    options = optionsClient(mocks.key, mocks.base, mocks.globalOptions);
+    return options.summaries({ 'ticker.any_of': "O:Ticker1,O:Ticker2" })
+        .then(function() { throw new Error('function should throw error'); })
+        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+  });
 });

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -214,7 +214,7 @@ describe("[REST] Stocks", () => {
     fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
     stocks = stocksClient(mocks.key, mocks.base, mocks.globalOptions);
     return stocks.summaries({ 'ticker.any_of': "AAPL,TSLA" })
-        .then(function() { throw new Error('function should throw error'); })
-        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+        .then(() => { throw new Error('function should throw error'); })
+        .catch((e) => { chai.expect(e).to.be.an.instanceof (Error); })
   });
 });

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -208,4 +208,13 @@ describe("[REST] Stocks", () => {
     fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
     fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
   });
+
+  it("properly handles promise rejections", async () => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').rejects('Error Message')
+    stocks = stocksClient(mocks.key, mocks.base, mocks.globalOptions);
+    return stocks.summaries({ 'ticker.any_of': "AAPL,TSLA" })
+        .then(function() { throw new Error('function should throw error'); })
+        .catch(function(e) { chai.expect(e).to.be.an.instanceof (Error); })
+  });
 });


### PR DESCRIPTION
When the fetch call results in a Rejected Promise, catch the error and re-throw so that it bubbles up correctly and doesn't trigger a global unhandledrejection event. 
This is related to Issue #131.