### PR TITLE
Exports and Updates Options WebSocket Event Types

### DIFF
--- a/src/websockets/index.ts
+++ b/src/websockets/index.ts
@@ -1,7 +1,7 @@
 import * as websocket from "websocket";
 import { getCryptoWebsocket } from "./crypto/index.js";
 import { getForexWebsocket } from "./forex/index.js";
-import { getIndicesWebsocket } from "./indices/index.js"
+import { getIndicesWebsocket } from "./indices/index.js";
 import { getOptionsWebsocket } from "./options/index.js";
 import { getStocksWebsocket } from "./stocks/index.js";
 
@@ -9,6 +9,7 @@ export * from "./forex/index.js";
 export * from "./indices/index.js";
 export * from "./stocks/index.js";
 export * from "./crypto/index.js";
+export * from "./options/index.js";
 
 export interface IWebsocketClient {
   crypto: () => websocket.w3cwebsocket;

--- a/src/websockets/options/index.ts
+++ b/src/websockets/options/index.ts
@@ -27,7 +27,21 @@ export interface ITradeOptionsEvent {
   s: number; // Trade Size
   c: number[]; // Trade Conditions
   t: number; // Trade Timestamp ( Unix MS )
+  q: number; // Sequence Number ( The sequence in which events ocurred )
 }
+
+export type IQuoteOptionsEvent = {
+  ev: string; // Event Type
+  sym: string; // Symbol Ticker
+  bx: number; // Bid Exchange ID
+  ax: number; // Ask Exchange ID
+  bp: number; // Bid Price
+  ap: number; // Ask Price
+  bs: number; // Bid Size
+  as: number; // Ask size
+  t: number; // Quote Timestamp ( Unix MS )
+  q: number; // Sequence Number ( The sequence in which events ocurred )
+};
 
 export const getOptionsWebsocket = (
   apiKey: string,


### PR DESCRIPTION
One event type was missing, and one had an additional property that wasn't defined in the interface.

Furthermore, the options file was not being exported from the library so once compiled I was not able to import them:
![image](https://user-images.githubusercontent.com/43946230/234172080-f9095589-7d16-4175-a64d-dd4b3ea09294.png)