### PR TITLE
Update header types and export types from request file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/main.d.ts",
   "type": "module",
   "exports": {
+    "types": "./dist/main.d.ts",
     "import": "./dist/main.js",
     "require": "./dist/main.cjs"
   },

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -11,6 +11,7 @@ export * from "./reference/index.js";
 export * from "./options/index.js";
 export * from "./stocks/index.js";
 export * from "./indices/index.js";
+export * from "./transport/request.js"; // ensure types are exported
 
 export interface IRestClient {
   crypto: ICryptoClient;

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -5,15 +5,15 @@ export interface IPolygonQuery {
   [key: string]: string | number | boolean | undefined;
 }
 
-export interface IPolygonEdgeHeaders extends Record<string, string> {
-   'X-Polygon-Edge-ID': string;
-   'X-Polygon-Edge-IP-Address': string;
+export interface IPolygonEdgeHeaders extends Partial<Record<string, string>> {
+   'X-Polygon-Edge-ID'?: string;
+   'X-Polygon-Edge-IP-Address'?: string;
    'X-Polygon-Edge-User-Agent'?: string;
 }
 
-export type IHeaders = IPolygonEdgeHeaders | Record<string, string>
+export type IHeaders = IPolygonEdgeHeaders | HeadersInit
 
-export interface IRequestInit extends RequestInit {
+export interface IRequestInit extends Omit<RequestInit, 'headers'> {
   headers?: IHeaders
 }
 


### PR DESCRIPTION
I updated the Launchpad header type definitions to fix the reported issue with partial Records. I also added an export of the requests file from index so that types defined in requests are included in the type definition bundle, and made all Launchpad headers optional to support Launchpad Metered.

Closes #157 