### PR TITLE
Update snapshot min to support n and t

### DIFF
--- a/src/rest/crypto/snapshots.ts
+++ b/src/rest/crypto/snapshots.ts
@@ -25,6 +25,8 @@ export interface SnapshotMin {
   o?: number;
   v?: number;
   vw?: number;
+  t?: number;
+  n?: number;
 }
 
 export interface SnapshotPrevDay {

--- a/src/rest/forex/snapshots.ts
+++ b/src/rest/forex/snapshots.ts
@@ -21,6 +21,8 @@ export interface SnapshotMin {
   l?: number;
   o?: number;
   v?: number;
+  t?: number;
+  n?: number;
 }
 
 export interface SnapshotPrevDay {

--- a/src/rest/stocks/snapshots.ts
+++ b/src/rest/stocks/snapshots.ts
@@ -43,6 +43,8 @@ export interface SnapshotPrevDay {
   o?: number;
   v?: number;
   vw?: number;
+  t?: number;
+  n?: number;
 }
 
 export interface SnapshotInfo {


### PR DESCRIPTION
Updated snapshot minute to support timestamp and number of transactions. Snapshots for stocks, forex, and crypto have been updated to support `t` and `n`. You can test this out via the [website docs](https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers).