### PR TITLE
Added request tracing and API pagination support

### DIFF
--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -27,7 +27,7 @@ export type IGet = (path: string, query: IPolygonQuery, options: IRequestOptions
 
 export interface IGlobalOptions extends IRequestOptions {
   trace?: boolean;
-  paginationEnabled?: boolean;
+  pagination?: boolean;
 }
 
 export type ICurriedGet = (apiKey: string, apiBase: string, globalOptions?: IGlobalOptions) => IGet;
@@ -106,7 +106,7 @@ export const getWithGlobals: ICurriedGet = (apiKey, apiBase, globalOptions = {})
         const newData = allData.concat(json.results);
 
         // check if there is a next page, pagination is enabled, and fetch it recursively
-        if(globalOptions.paginationEnabled && json.next_url) {
+        if(globalOptions.pagination && json.next_url) {
           const nextPath = json.next_url.replace(apiBase, "");
           return fetchPage(nextPath, {}, options, newData);
         } else {

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -24,7 +24,13 @@ export interface IPolygonQueryWithCredentials extends IPolygonQuery {
 }
 
 export type IGet = (path: string, query: IPolygonQuery, options: IRequestOptions) => Promise<any>;
-export type ICurriedGet = (apiKey: string, apiBase: string, globalOptions?: IRequestOptions & { trace?: boolean }) => IGet;
+
+export interface IGlobalOptions extends IRequestOptions {
+  trace?: boolean;
+  paginationEnabled?: boolean;
+}
+
+export type ICurriedGet = (apiKey: string, apiBase: string, globalOptions?: IGlobalOptions) => IGet;
 export type IStructuredError = InstanceType<typeof StructuredError>;
 
 class StructuredError extends Error {
@@ -99,8 +105,8 @@ export const getWithGlobals: ICurriedGet = (apiKey, apiBase, globalOptions = {})
         const json = await response.json();
         const newData = allData.concat(json.results);
 
-        // check if there is a next page and fetch it recursively
-        if(json.next_url) {
+        // check if there is a next page, pagination is enabled, and fetch it recursively
+        if(globalOptions.paginationEnabled && json.next_url) {
           const nextPath = json.next_url.replace(apiBase, "");
           return fetchPage(nextPath, {}, options, newData);
         } else {


### PR DESCRIPTION
This PR introduces improvements around request tracing and pagination, although distinct, I chose to bundle them into a single PR due to their interrelatedness. When dealing with APIs returning paginated results, figuring out what urls are being fetched becomes pretty complex without added logging. So, just adding the request tracing feature alongside pagination support, greatly simplifies the debugging -- that's why you see the two improvements in one PR. We added tracing to the python client already and will do the same for Go. So, this adds consistency too.

**Request Tracing**: A new optional `trace` parameter in `globalOptions` enables request and response logging for debugging purposes. When activated, the request URL, sanitized headers, and response headers are logged in the console.

Here's an example script:

```python
import('@polygon.io/client-js').then(({ restClient }) => {
	const globalFetchOptions = {
		trace: true
	};
	const rest = restClient("XXXXX", "https://api.polygon.io", globalFetchOptions);

	rest.stocks.aggregates("AAPL", 1, "minute", "2019-01-01", "2023-02-01", { limit: 50000 }).then((data) => {
		//	console.log(data);
	    // Count the results
	    const resultCount = data.length;
	    console.log("Result count:", resultCount);
	}).catch(e => {
		console.error('An error happened:', e);
	});
});
```

The output looks like this:

```
root@b3d6fa7e1b1a:~/polygon/client-js-testing# node examples/rest/stocks-aggregates_bars.js
Request URL:  https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/2019-01-01/2023-02-01?limit=50000
Request Headers:  { Authorization: 'Bearer REDACTED' }
Response Headers:  Headers {
  [Symbol(map)]: [Object: null prototype] {
    server: [ 'nginx/1.19.2' ],
    date: [ 'Thu, 15 Jun 2023 06:32:32 GMT' ],
    'content-type': [ 'application/json' ],
    'transfer-encoding': [ 'chunked' ],
    connection: [ 'close' ],
    'content-encoding': [ 'gzip' ],
    vary: [ 'Accept-Encoding' ],
    'x-request-id': [ '51e0ec5ce99715f726192787a960c7ac' ],
    'strict-transport-security': [ 'max-age=15724800; includeSubDomains' ]
  }
}
```

Which can be extremely useful for figuring out what url API you're talking to and what the client and server headers are (the `x-request-id` is really useful for support).

**Pagination Support**: getWithGlobals can now handle APIs returning paginated results (fixes https://github.com/polygon-io/client-js/issues/103). The function will automatically fetch all pages of data when the API response indicates more data is available.

In the old version, each call to getWithGlobals could only retrieve a single "page" of data from the server. This would only provide the first page of results, and the end user application would need to have logic to retrieve all of the data.

Here's a test script (current version):

```python
import('@polygon.io/client-js').then(({ restClient }) => {
	const rest = restClient("XXXXX", "https://api.polygon.io");

	rest.stocks.aggregates("AAPL", 1, "minute", "2019-01-01", "2023-02-01", { limit: 50000 }).then((data) => {
		//	console.log(data);
	    // Count the results
	    const resultCount = data.length;
	    console.log("Result count:", resultCount);
	}).catch(e => {
		console.error('An error happened:', e);
	});
});
```

Here's the output:

```
root@b3d6fa7e1b1a:~/polygon/client-js-testing# node examples/rest/stocks-aggregates_bars.js
Result count: 50000
```

In the new version, the getWithGlobals function uses a nested function fetchPage to fetch a page of data, and then check if there's another page to fetch. This is done by looking for a next_url property in the JSON response. If there is a next_url, it calls itself recursively to fetch the next page, passing along the accumulated data so far.

Here's a test script (new version -- try turning on tracing too):

```python
import('@polygon.io/client-js').then(({ restClient }) => {
	const globalFetchOptions = {
		trace: true
	};
	const rest = restClient("XXXXX", "https://api.polygon.io", globalFetchOptions);

	rest.stocks.aggregates("AAPL", 1, "minute", "2019-01-01", "2023-02-01", { limit: 50000 }).then((data) => {
		//	console.log(data);
	    // Count the results
	    const resultCount = data.length;
	    console.log("Result count:", resultCount);
	}).catch(e => {
		console.error('An error happened:', e);
	});
});
```

Here's the output:

```
root@b3d6fa7e1b1a:~/polygon/client-js-testing# node examples/rest/stocks-aggregates_bars.js
Result count: 796098
```

The best part is, these changes are entirely transparent to the user and require no changes to their existing code. This hopefully provides a "just works" experience for users of the client-js library.