### PR TITLE
Update require syntax in examples to use import instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ npm install --save @polygon.io/client-js
 Next, create a new client with your [API key](https://polygon.io/dashboard/signup).
 
 ```javascript
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 ```
 
 ## Using the client
@@ -61,7 +61,8 @@ rest.stocks.snapshotAllTickers().then((data) => {
 });
 ```
 
-See [full examples](./examples/rest/) for more details on how to use this client effectively.
+See [full examples](./examples/rest/) for more details on how to use this client effectively. 
+To run these examples from the command line, first check out this project and run ```npm i``` in the root directory to install dependencies, then run ```POLY_API_KEY=yourAPIKey node examples/rest/crypto-aggregates_bars.js```, replacing yourAPIKey with your Polygon API Key. 
 
 ## Launchpad Usage
 
@@ -73,7 +74,7 @@ Import the [Websocket](https://polygon.io/docs/stocks/ws_getting-started) client
 
 ```javascript
 import { websocketClient } from "@polygon.io/client-js";
-const stocksWS = websocketClient("API KEY").stocks();
+const stocksWS = websocketClient(process.env.POLY_API_KEY).stocks();
 
 stocksWS.onmessage = ({data}) => {
   const [message] = JSON.parse(data);

--- a/examples/rest/configuration.js
+++ b/examples/rest/configuration.js
@@ -1,10 +1,10 @@
-const { restClient } = require('@polygon.io/client-js');
+import { restClient } from '@polygon.io/client-js';
 
 // You can pass global options to fetch to add headers or configure requests
 const globalFetchOptions = {
 	method: 'HEAD'
 }
-const rest = restClient("API KEY", "https://api.polygon.io", globalFetchOptions);
+const rest = restClient(process.env.POLY_API_KEY, "https://api.polygon.io", globalFetchOptions);
 
 // You can also pass options to each individual call, each key will override keys from the options also set globally
 

--- a/examples/rest/crypto-aggregates_bars.js
+++ b/examples/rest/crypto-aggregates_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoticker__range__multiplier___timespan___from___to
 rest.crypto.aggregates("X:BTCUSD", 1, "day", "2023-01-30", "2023-02-03").then((data) => {

--- a/examples/rest/crypto-conditions.js
+++ b/examples/rest/crypto-conditions.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v3_reference_conditions
 rest.reference.conditions({ asset_class: "crypto", limit: 1000 }).then((data) => {

--- a/examples/rest/crypto-daily_open_close.js
+++ b/examples/rest/crypto-daily_open_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_open-close_crypto__from___to___date
 rest.crypto.dailyOpenClose("BTC", "USD", "2019-01-01").then((data) => {

--- a/examples/rest/crypto-exchanges.js
+++ b/examples/rest/crypto-exchanges.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v3_reference_exchanges
 rest.reference.exchanges({ asset_class: "crypto", limit: 1000 }).then((data) => {

--- a/examples/rest/crypto-grouped_daily_bars.js
+++ b/examples/rest/crypto-grouped_daily_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_aggs_grouped_locale_global_market_crypto__date
 rest.crypto.aggregatesGroupedDaily("2023-03-31").then((data) => {

--- a/examples/rest/crypto-last_trade_for_a_crypto_pair.js
+++ b/examples/rest/crypto-last_trade_for_a_crypto_pair.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_last_crypto__from___to
 rest.crypto.lastTrade("BTC", "USD").then((data) => {

--- a/examples/rest/crypto-market_holidays.js
+++ b/examples/rest/crypto-market_holidays.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_marketstatus_upcoming
 rest.reference.marketHolidays().then((data) => {

--- a/examples/rest/crypto-market_status.js
+++ b/examples/rest/crypto-market_status.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_marketstatus_now
 rest.reference.marketStatus().then((data) => {

--- a/examples/rest/crypto-previous_close.js
+++ b/examples/rest/crypto-previous_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoticker__prev
 rest.crypto.previousClose("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-snapshots_all_tickers.js
+++ b/examples/rest/crypto-snapshots_all_tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers
 rest.crypto.snapshotAllTickers("").then((data) => {

--- a/examples/rest/crypto-snapshots_gainers_losers.js
+++ b/examples/rest/crypto-snapshots_gainers_losers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto__direction
 // gainers

--- a/examples/rest/crypto-snapshots_ticker.js
+++ b/examples/rest/crypto-snapshots_ticker.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker
 rest.crypto.snapshotTicker("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-snapshots_ticker_full_book_l2.js
+++ b/examples/rest/crypto-snapshots_ticker_full_book_l2.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker__book
 rest.crypto.snapshotTickerFullBookL2("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-technical_indicators_ema.js
+++ b/examples/rest/crypto-technical_indicators_ema.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_indicators_ema__cryptoticker
 rest.crypto.ema("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-technical_indicators_macd.js
+++ b/examples/rest/crypto-technical_indicators_macd.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_indicators_macd__cryptoticker
 rest.crypto.macd("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-technical_indicators_rsi.js
+++ b/examples/rest/crypto-technical_indicators_rsi.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // hhttps://polygon.io/docs/crypto/get_v1_indicators_rsi__cryptoticker
 rest.crypto.rsi("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-technical_indicators_sma.js
+++ b/examples/rest/crypto-technical_indicators_sma.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v1_indicators_sma__cryptoticker
 rest.crypto.sma("X:BTCUSD").then((data) => {

--- a/examples/rest/crypto-tickers.js
+++ b/examples/rest/crypto-tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v3_reference_tickers
 rest.reference.tickers({ market: "crypto", limit: 1000 }).then((data) => {

--- a/examples/rest/crypto-trades.js
+++ b/examples/rest/crypto-trades.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/crypto/get_v3_trades__cryptoticker
 rest.crypto.trades("X:BTCUSD").then((data) => {

--- a/examples/rest/forex-aggregates_bars.js
+++ b/examples/rest/forex-aggregates_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_aggs_ticker__forexticker__range__multiplier___timespan___from___to
 rest.forex.aggregates("C:EURUSD", 1, "day", "2019-01-01", "2019-02-01").then((data) => {

--- a/examples/rest/forex-conditions.js
+++ b/examples/rest/forex-conditions.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v3_reference_conditions
 rest.reference.conditions({ asset_class: "fx", limit: 1000 }).then((data) => {

--- a/examples/rest/forex-exchanges.js
+++ b/examples/rest/forex-exchanges.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v3_reference_exchanges
 rest.reference.exchanges({ asset_class: "fx", limit: 1000 }).then((data) => {

--- a/examples/rest/forex-grouped_daily_bars.js
+++ b/examples/rest/forex-grouped_daily_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_aggs_grouped_locale_global_market_fx__date
 rest.forex.aggregatesGroupedDaily("2023-03-31").then((data) => {

--- a/examples/rest/forex-last_quote_for_a_currency_pair.js
+++ b/examples/rest/forex-last_quote_for_a_currency_pair.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_last_quote_currencies__from___to
 rest.forex.lastQuote("AUD", "USD").then((data) => {

--- a/examples/rest/forex-market_holidays.js
+++ b/examples/rest/forex-market_holidays.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_marketstatus_upcoming
 rest.reference.marketHolidays().then((data) => {

--- a/examples/rest/forex-market_status.js
+++ b/examples/rest/forex-market_status.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_marketstatus_now
 rest.reference.marketStatus().then((data) => {

--- a/examples/rest/forex-previous_close.js
+++ b/examples/rest/forex-previous_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_aggs_ticker__forexticker__prev
 rest.forex.previousClose("C:EURUSD").then((data) => {

--- a/examples/rest/forex-quotes.js
+++ b/examples/rest/forex-quotes.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v3_quotes__fxticker
 rest.forex.quotes("C:EUR-USD").then((data) => {

--- a/examples/rest/forex-real-time_currency_conversion.js
+++ b/examples/rest/forex-real-time_currency_conversion.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_conversion__from___to
 rest.forex.conversion("AUD", "USD").then((data) => {

--- a/examples/rest/forex-snapshots_all_tickers.js
+++ b/examples/rest/forex-snapshots_all_tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers
 rest.forex.snapshotTicker("").then((data) => {

--- a/examples/rest/forex-snapshots_gainers_losers.js
+++ b/examples/rest/forex-snapshots_gainers_losers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex__direction
 // gainers

--- a/examples/rest/forex-snapshots_ticker.js
+++ b/examples/rest/forex-snapshots_ticker.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers__ticker
 rest.forex.snapshotTicker("C:EURUSD").then((data) => {

--- a/examples/rest/forex-technical_indicators_ema.js
+++ b/examples/rest/forex-technical_indicators_ema.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_indicators_ema__fxticker
 rest.forex.ema("C:EURUSD", 

--- a/examples/rest/forex-technical_indicators_macd.js
+++ b/examples/rest/forex-technical_indicators_macd.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_indicators_macd__fxticker
 rest.forex.macd("C:EURUSD").then((data) => {

--- a/examples/rest/forex-technical_indicators_rsi.js
+++ b/examples/rest/forex-technical_indicators_rsi.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_indicators_rsi__fxticker
 rest.forex.rsi("C:EURUSD").then((data) => {

--- a/examples/rest/forex-technical_indicators_sma.js
+++ b/examples/rest/forex-technical_indicators_sma.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v1_indicators_sma__fxticker
 rest.forex.sma("C:EURUSD").then((data) => {

--- a/examples/rest/forex-tickers.js
+++ b/examples/rest/forex-tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/forex/get_v3_reference_tickers
 rest.reference.tickers({ market: "fx", limit: 1000 }).then((data) => {

--- a/examples/rest/indices-aggregates_bars.js
+++ b/examples/rest/indices-aggregates_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v2_aggs_ticker__indicesticker__range__multiplier___timespan___from___to
 rest.indices.aggregates("I:SPX", 1, "day", "2023-03-10", "2023-03-10").then((data) => {

--- a/examples/rest/indices-daily_open_close.js
+++ b/examples/rest/indices-daily_open_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_open-close__indicesticker___date
 rest.indices.dailyOpenClose("I:SPX", "2023-03-31").then((data) => {

--- a/examples/rest/indices-market_holidays.js
+++ b/examples/rest/indices-market_holidays.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_marketstatus_upcoming
 rest.reference.marketHolidays().then((data) => {

--- a/examples/rest/indices-market_status.js
+++ b/examples/rest/indices-market_status.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_marketstatus_now
 rest.reference.marketStatus().then((data) => {

--- a/examples/rest/indices-previous_close.js
+++ b/examples/rest/indices-previous_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v2_aggs_ticker__indicesticker__prev
 rest.indices.previousClose("I:SPX").then((data) => {

--- a/examples/rest/indices-snapshots.js
+++ b/examples/rest/indices-snapshots.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v3_snapshot_indices
 rest.indices.snapshotTicker({ "ticker.any_of": "I:SPX" }).then((data) => {

--- a/examples/rest/indices-technical_indicators_ema.js
+++ b/examples/rest/indices-technical_indicators_ema.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_indicators_ema__indicesticker
 rest.indices.ema("I:SPX").then((data) => {

--- a/examples/rest/indices-technical_indicators_macd.js
+++ b/examples/rest/indices-technical_indicators_macd.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_indicators_macd__indicesticker
 rest.indices.macd("I:SPX").then((data) => {

--- a/examples/rest/indices-technical_indicators_rsi.js
+++ b/examples/rest/indices-technical_indicators_rsi.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_indicators_rsi__indicesticker
 rest.indices.rsi("I:SPX").then((data) => {

--- a/examples/rest/indices-technical_indicators_sma.js
+++ b/examples/rest/indices-technical_indicators_sma.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v1_indicators_sma__indicesticker
 rest.indices.sma("I:SPX").then((data) => {

--- a/examples/rest/indices-ticker_types.js
+++ b/examples/rest/indices-ticker_types.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v3_reference_tickers_types
 rest.reference.tickerTypes({ asset_class: "indices"}).then((data) => {

--- a/examples/rest/indices-tickers.js
+++ b/examples/rest/indices-tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/indices/get_v3_reference_tickers
 rest.reference.tickers({ market: "indices", limit: 1000 }).then((data) => {

--- a/examples/rest/launchpad/README.md
+++ b/examples/rest/launchpad/README.md
@@ -18,9 +18,9 @@ const edgeHeaders = {
   'X-Polygon-Edge-User-Agent': useragent
 }
 
-const rest = restClient("API KEY", "https://api.polygon.io");
+const rest = restClient(process.env.POLY_API_KEY);
 rest.forex.previousClose("C:EURUSD", {}, { headers: edgeHeaders }).then(/* your success handler */);
 
-const reference = referenceClient("API KEY", "https://api.polygon.io");
+const reference = referenceClient(process.env.POLY_API_KEY);
 reference.tickers({}, { headers: edgeHeaders }).then(/* your success handler */);
 ```

--- a/examples/rest/launchpad/index.js
+++ b/examples/rest/launchpad/index.js
@@ -11,8 +11,8 @@ const edgeHeaders = {
   'X-Polygon-Edge-User-Agent': 'useragent'
 }
 
-const rest = restClient("API KEY", "https://api.polygon.io");
+const rest = restClient(process.env.POLY_API_KEY);
 rest.forex.previousClose("C:EURUSD", {}, { headers: edgeHeaders }).then(/* your success handler */);
 
-const reference = referenceClient("API KEY", "https://api.polygon.io");
+const reference = referenceClient(process.env.POLY_API_KEY);
 reference.tickers({}, { headers: edgeHeaders }).then(/* your success handler */);

--- a/examples/rest/options-aggregates_bars.js
+++ b/examples/rest/options-aggregates_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__range__multiplier___timespan___from___to
 rest.options.aggregates("O:SPY251219C00650000", 1, "day", "2023-01-09", "2023-01-09").then((data) => {

--- a/examples/rest/options-conditions.js
+++ b/examples/rest/options-conditions.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_conditions
 rest.reference.conditions({ asset_class: "options", limit: 1000 }).then((data) => {

--- a/examples/rest/options-contract.js
+++ b/examples/rest/options-contract.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker
 rest.reference.optionsContract("O:EVRI240119C00002500").then((data) => {

--- a/examples/rest/options-contracts.js
+++ b/examples/rest/options-contracts.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_options_contracts
 rest.reference.optionsContracts().then((data) => {

--- a/examples/rest/options-daily_open_close.js
+++ b/examples/rest/options-daily_open_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_open-close__optionsticker___date
 rest.options.dailyOpenClose("O:SPY251219C00650000", "2023-03-31").then((data) => {

--- a/examples/rest/options-exchanges.js
+++ b/examples/rest/options-exchanges.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_exchanges
 rest.reference.exchanges({ asset_class: "options", limit: 1000 }).then((data) => {

--- a/examples/rest/options-last_trade.js
+++ b/examples/rest/options-last_trade.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v2_last_trade__optionsticker
 rest.options.lastTrade("O:TSLA210903C00700000").then((data) => {

--- a/examples/rest/options-market_holidays.js
+++ b/examples/rest/options-market_holidays.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_marketstatus_upcoming
 rest.reference.marketHolidays().then((data) => {

--- a/examples/rest/options-market_status.js
+++ b/examples/rest/options-market_status.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_marketstatus_now
 rest.reference.marketStatus().then((data) => {

--- a/examples/rest/options-previous_close.js
+++ b/examples/rest/options-previous_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__prev
 rest.options.previousClose("O:SPY251219C00650000").then((data) => {

--- a/examples/rest/options-quotes.js
+++ b/examples/rest/options-quotes.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_quotes__optionsticker
 rest.options.quotes("O:SPY241220P00720000").then((data) => {

--- a/examples/rest/options-snapshots_option_contract.js
+++ b/examples/rest/options-snapshots_option_contract.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset___optioncontract
 rest.options.snapshotOptionContract("AAPL", "O:AAPL230616C00150000").then((data) => {

--- a/examples/rest/options-snapshots_options_chain.js
+++ b/examples/rest/options-snapshots_options_chain.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset
 rest.options.snapshotOptionChain("AAPL").then((data) => {

--- a/examples/rest/options-technical_indicators_ema.js
+++ b/examples/rest/options-technical_indicators_ema.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_indicators_ema__optionsticker
 rest.options.ema("AAPL").then((data) => {

--- a/examples/rest/options-technical_indicators_macd.js
+++ b/examples/rest/options-technical_indicators_macd.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_indicators_macd__optionsticker
 rest.options.macd("O:SPY241220P00720000").then((data) => {

--- a/examples/rest/options-technical_indicators_rsi.js
+++ b/examples/rest/options-technical_indicators_rsi.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_indicators_rsi__optionsticker
 rest.options.rsi("O:SPY241220P00720000").then((data) => {

--- a/examples/rest/options-technical_indicators_sma.js
+++ b/examples/rest/options-technical_indicators_sma.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v1_indicators_sma__optionsticker
 rest.options.sma("O:SPY241220P00720000").then((data) => {

--- a/examples/rest/options-ticker_details.js
+++ b/examples/rest/options-ticker_details.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_tickers__ticker
 rest.reference.tickerDetails("AAPL").then((data) => {

--- a/examples/rest/options-ticker_news.js
+++ b/examples/rest/options-ticker_news.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v2_reference_news
 rest.reference.tickerNews("AAPL").then((data) => {

--- a/examples/rest/options-tickers.js
+++ b/examples/rest/options-tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_reference_tickers
 rest.reference.tickers({ market: "stocks", limit: 1000 }).then((data) => {

--- a/examples/rest/options-trades.js
+++ b/examples/rest/options-trades.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/options/get_v3_trades__optionsticker
 rest.options.trades("O:TSLA210903C00700000").then((data) => {

--- a/examples/rest/stocks-aggregates_bars.js
+++ b/examples/rest/stocks-aggregates_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
 rest.stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01").then((data) => {

--- a/examples/rest/stocks-conditions.js
+++ b/examples/rest/stocks-conditions.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_conditions
 rest.reference.conditions({ asset_class: "stocks", limit: 1000 }).then((data) => {

--- a/examples/rest/stocks-daily_open_close.js
+++ b/examples/rest/stocks-daily_open_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
 rest.stocks.dailyOpenClose("AAPL", "2023-03-31").then((data) => {

--- a/examples/rest/stocks-dividends.js
+++ b/examples/rest/stocks-dividends.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_dividends
 rest.reference.dividends("AAPL").then((data) => {

--- a/examples/rest/stocks-exchanges.js
+++ b/examples/rest/stocks-exchanges.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_exchanges
 rest.reference.exchanges({ asset_class: "stocks" }).then((data) => {

--- a/examples/rest/stocks-grouped_daily_bars.js
+++ b/examples/rest/stocks-grouped_daily_bars.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
 rest.stocks.aggregatesGroupedDaily("2023-03-31").then((data) => {

--- a/examples/rest/stocks-last_quote.js
+++ b/examples/rest/stocks-last_quote.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
 rest.stocks.lastQuote("AAPL").then((data) => {

--- a/examples/rest/stocks-last_trade.js
+++ b/examples/rest/stocks-last_trade.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_last_trade__stocksticker
 rest.stocks.lastTrade("AAPL").then((data) => {

--- a/examples/rest/stocks-market_holidays.js
+++ b/examples/rest/stocks-market_holidays.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
 rest.reference.marketHolidays().then((data) => {

--- a/examples/rest/stocks-market_status.js
+++ b/examples/rest/stocks-market_status.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_marketstatus_now
 rest.reference.marketStatus().then((data) => {

--- a/examples/rest/stocks-previous_close.js
+++ b/examples/rest/stocks-previous_close.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__prev
 rest.stocks.previousClose("AAPL").then((data) => {

--- a/examples/rest/stocks-quotes.js
+++ b/examples/rest/stocks-quotes.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_quotes__stockticker
 rest.stocks.quotes("HCP").then((data) => {

--- a/examples/rest/stocks-snapshots_all.js
+++ b/examples/rest/stocks-snapshots_all.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers
 rest.stocks.snapshotAllTickers().then((data) => {

--- a/examples/rest/stocks-snapshots_gainers_losers.js
+++ b/examples/rest/stocks-snapshots_gainers_losers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks__direction
 // gainers

--- a/examples/rest/stocks-snapshots_ticker.js
+++ b/examples/rest/stocks-snapshots_ticker.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers__stocksticker
 rest.stocks.snapshotTicker("AAPL").then((data) => {

--- a/examples/rest/stocks-stock_financials.js
+++ b/examples/rest/stocks-stock_financials.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_vx_reference_financials
 rest.reference.stockFinancials("AAPL").then((data) => {

--- a/examples/rest/stocks-stock_splits.js
+++ b/examples/rest/stocks-stock_splits.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_splits
 rest.reference.stockSplits("AAPL").then((data) => {

--- a/examples/rest/stocks-technical_indicators_ema.js
+++ b/examples/rest/stocks-technical_indicators_ema.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_indicators_ema__stockticker
 rest.stocks.ema("AAPL").then((data) => {

--- a/examples/rest/stocks-technical_indicators_macd.js
+++ b/examples/rest/stocks-technical_indicators_macd.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 rest.stocks.macd("AAPL").then((data) => {

--- a/examples/rest/stocks-technical_indicators_rsi.js
+++ b/examples/rest/stocks-technical_indicators_rsi.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_indicators_rsi__stockticker
 rest.stocks.rsi("AAPL").then((data) => {

--- a/examples/rest/stocks-technical_indicators_sma.js
+++ b/examples/rest/stocks-technical_indicators_sma.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v1_indicators_sma__stockticker
 rest.stocks.sma("AAPL").then((data) => {

--- a/examples/rest/stocks-ticker_details.js
+++ b/examples/rest/stocks-ticker_details.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
 rest.reference.tickerDetails("AAPL").then((data) => {

--- a/examples/rest/stocks-ticker_news.js
+++ b/examples/rest/stocks-ticker_news.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v2_reference_news
 rest.reference.tickerNews("AAPL").then((data) => {

--- a/examples/rest/stocks-ticker_types.js
+++ b/examples/rest/stocks-ticker_types.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_tickers_types
 rest.reference.tickerTypes({ asset_class: "stocks"}).then((data) => {

--- a/examples/rest/stocks-tickers.js
+++ b/examples/rest/stocks-tickers.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_reference_tickers
 rest.reference.tickers({ market: "stocks", limit: 1000 }).then((data) => {

--- a/examples/rest/stocks-trades.js
+++ b/examples/rest/stocks-trades.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // https://polygon.io/docs/stocks/get_v3_trades__stockticker
 rest.stocks.trades("HCP").then((data) => {

--- a/examples/rest/universal-snapshot.js
+++ b/examples/rest/universal-snapshot.js
@@ -1,5 +1,5 @@
-const { restClient } = require('@polygon.io/client-js');
-const rest = restClient("API KEY", "https://api.polygon.io");
+import { restClient } from '@polygon.io/client-js';
+const rest = restClient(process.env.POLY_API_KEY);
 
 // You can access the universal snapshot endpoint from any asset class client
 

--- a/examples/websocket/advanced.js
+++ b/examples/websocket/advanced.js
@@ -1,7 +1,8 @@
 
-const lodash = require('lodash')
-const WebSocket = require('ws')
-const EventEmitter = require('events').EventEmitter
+import lodash from 'lodash';
+import WebSocket from 'ws';
+import { EventEmitter } from 'events';
+
 const APIKEY = process.env.POLY_API_KEY || 'YOUR_API_KEY'
 
 

--- a/examples/websocket/index.js
+++ b/examples/websocket/index.js
@@ -1,4 +1,5 @@
-const WebSocket = require('ws')
+import WebSocket from 'ws';
+
 const APIKEY = process.env.POLY_API_KEY || 'YOUR_API_KEY'
 
 // Connection Type:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,15 +24,18 @@
         "@types/sinon": "^10.0.6",
         "@types/websocket": "^1.0.4",
         "chai": "^4.3.4",
+        "events": "^3.3.0",
         "husky": "^7.0.4",
         "lint-staged": "^12.1.2",
+        "lodash": "^4.17.21",
         "mocha": "^9.1.3",
         "prettier": "^2.5.1",
         "sinon": "^12.0.1",
         "ts-node": "^10.9.1",
         "tsup": "^6.7.0",
         "typedoc": "^0.22.10",
-        "typescript": "^4.5.2"
+        "typescript": "^4.5.2",
+        "ws": "^8.13.0"
       },
       "engines": {
         "node": ">=16"
@@ -1162,6 +1165,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -1803,6 +1815,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -3138,6 +3156,27 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3994,6 +4033,12 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4438,6 +4483,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -5382,6 +5433,13 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -59,15 +59,18 @@
     "@types/sinon": "^10.0.6",
     "@types/websocket": "^1.0.4",
     "chai": "^4.3.4",
+    "events": "^3.3.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
+    "lodash": "^4.17.21",
     "mocha": "^9.1.3",
     "prettier": "^2.5.1",
     "sinon": "^12.0.1",
     "ts-node": "^10.9.1",
     "tsup": "^6.7.0",
     "typedoc": "^0.22.10",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "ws": "^8.13.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I also updated the client initialization to use an env variable so you should be able to easily run any example like `POLY_API_KEY=yourAPIKey node examples/rest/crypto-aggregates_bars.js`. Added the dependencies needed to run the websocket examples as dev dependencies, so those can be run too.