### PR TITLE
Fixes the response format, also adds tests to make sure changes to this have coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## [7.3.0](https://github.com/polygon-io/client-js/compare/v7.2.6...v7.3.0) (2023-08-11)
+## [7.3.1](https://github.com/polygon-io/client-js/compare/v7.3.0...v7.3.1) (2023-09-15)
+### Bug Fixes
+* Fix unintended change to top level response object that returned results array instead of results object
+
+### Other Changes
+* Improved test coverage for response object
+
+## [7.3.0](https://github.com/polygon-io/client-js/compare/v7.2.6...v7.3.0) (2023-09-11)
 ### New Feature
 * Update README with pagination and trace modes
 * Added request tracing and API pagination support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@polygon.io/client-js",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "license": "MIT",
       "workspaces": [
         "./dist/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/rest/crypto/index.test.ts
+++ b/src/rest/crypto/index.test.ts
@@ -37,6 +37,12 @@ describe("[REST] Crypto", () => {
     sandbox.restore();
   });
 
+  it("should have appropriate results", async () => {
+    setStub({ results: [{ o: 1}] });
+    const response = await crypto.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results![0].t?.should.eql(1);
+  });
+
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
     setStub({ results: [] });
     await crypto.aggregates("BTC", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);

--- a/src/rest/forex/index.test.ts
+++ b/src/rest/forex/index.test.ts
@@ -37,6 +37,12 @@ describe("[REST] Forex / Currencies", () => {
     sandbox.restore();
   });
 
+  it("should have appropriate results", async () => {
+    setStub({ results: [{ o: 1}] });
+    const response = await fx.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results![0].t?.should.eql(1);
+  });
+
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
     setStub({ results: [] });
     await fx.aggregates("EURCHF", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);

--- a/src/rest/indices/index.test.ts
+++ b/src/rest/indices/index.test.ts
@@ -38,6 +38,12 @@ describe("[REST] Indices", () => {
     sandbox.restore();
   });
 
+  it("should have appropriate results", async () => {
+    setStub({ results: [{ o: 1}] });
+    const response = await indices.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results![0].t?.should.eql(1);
+  });
+
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
     setStub({ results: [] });
     await indices.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);

--- a/src/rest/options/index.test.ts
+++ b/src/rest/options/index.test.ts
@@ -38,6 +38,12 @@ describe("[REST] Options", () => {
     sandbox.restore();
   });
 
+  it("should have appropriate results", async () => {
+    setStub({ results: [{ o: 1}] });
+    const response = await options.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results![0].t?.should.eql(1);
+  });
+
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
     setStub({ results: [] });
     await options.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);

--- a/src/rest/stocks/index.test.ts
+++ b/src/rest/stocks/index.test.ts
@@ -38,13 +38,20 @@ describe("[REST] Stocks", () => {
     sandbox.restore();
   });
 
+  it("should have appropriate results", async () => {
+    setStub({ results: [{ o: 1}] });
+    const response = await stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results![0].t?.should.eql(1);
+  });
+
   it("aggregates call /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}", async () => {
-    setStub({ results: [] });
-    await stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
+    setStub({ results: [{ o: 1}] });
+    const response = await stocks.aggregates("AAPL", 1, "day", "2019-01-01", "2019-02-01", mocks.query, mocks.overrideOptions);
     fetchStub.callCount.should.eql(1);
     getPath(fetchStub.getCalls()[0].args[0]).should.eql(
       "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
     );
+    response.results?.[0].o?.should.eql(1);
     fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
     fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
     fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);

--- a/src/rest/transport/index.test.ts
+++ b/src/rest/transport/index.test.ts
@@ -1,0 +1,76 @@
+import * as sinon from "sinon";
+import * as chai from "chai";
+import fetchModule from '../transport/fetch';
+import {  getWithGlobals } from '../transport/request';
+
+describe("[REST] Stocks", () => {
+  chai.should();
+  const mocks = {
+    key: 'invalid',
+    base: 'https://test.api.polygon.io',
+    query: { query1: 'queryVal' },
+    overrideOptions: {
+      referrer: 'overrideVal'
+    },
+    globalOptions: {
+      referrer: 'globalVal1',
+      headers: {
+        header1: 'headerVal1'
+      }
+    }
+  };
+  let fetchStub;
+  const sandbox = sinon.createSandbox();
+  const getPath = (url) => url.slice(mocks.base.length, url.indexOf('?'));
+  const setStub = (returnVal, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal), status } as Response)
+    );
+  }
+  const setStubs = (returnVal1, returnVal2, status = 200) => {
+    fetchStub?.restore();
+    fetchStub = sandbox.stub(fetchModule, 'fetch').onCall(0).returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal1), status } as Response)
+    ).onCall(1).returns(
+      Promise.resolve({ json: () => Promise.resolve(returnVal2), status } as Response)      
+    );
+  }
+  beforeEach(async () => {
+    setStub({ ticks: [], results: [], tickers: [] });
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Returns the expected result when pagination is not enabled", async () => {
+    setStub({ results: [{ a: 1 }] });
+    const requestFn = getWithGlobals(mocks.key, mocks.base, mocks.globalOptions);
+		const response = await requestFn("/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01", mocks.query, mocks.overrideOptions);
+		response.results[0].a.should.eql(1);
+    fetchStub.callCount.should.eql(1);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
+    );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+
+
+  it("Returns the expected result when pagination is enabled", async () => {
+    setStubs({ results: [{ a: 1 }], next_url: "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-02" }, { results: [{ b: 2 }],  });
+    const requestFn = getWithGlobals(mocks.key, mocks.base, {...mocks.globalOptions, pagination: true});
+		const response = await requestFn("/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01", mocks.query, mocks.overrideOptions);
+    response.results.length.should.eql(2);
+		response.results[0].a.should.eql(1);
+    response.results[1].b.should.eql(2);
+    fetchStub.callCount.should.eql(2);
+    getPath(fetchStub.getCalls()[0].args[0]).should.eql(
+      "/v2/aggs/ticker/AAPL/range/1/day/2019-01-01/2019-02-01"
+    );
+    fetchStub.getCalls()[0].args[0].indexOf(mocks.query.query1).should.be.gt(-1);
+    fetchStub.getCalls()[0].args[1].referrer.should.eql(mocks.overrideOptions.referrer);
+    fetchStub.getCalls()[0].args[1].headers.header1.should.eql(mocks.globalOptions.headers.header1);
+  });
+});

--- a/src/rest/transport/request.ts
+++ b/src/rest/transport/request.ts
@@ -103,14 +103,18 @@ export const getWithGlobals: ICurriedGet = (apiKey, apiBase, globalOptions = {})
         }
 
         const json = await response.json();
-        const newData = allData.concat(json.results);
+        const newData = json.results instanceof Array ? allData.concat(json.results) : allData;
 
-        // check if there is a next page, pagination is enabled, and fetch it recursively
-        if(globalOptions.pagination && json.next_url) {
+        if(globalOptions?.pagination && json.next_url) {
+          // check if there is a next page, pagination is enabled, and fetch it recursively
           const nextPath = json.next_url.replace(apiBase, "");
           return fetchPage(nextPath, {}, options, newData);
+        } else if (globalOptions?.pagination) {
+          // check if there is a next page, pagination is enabled, and fetch it recursively
+          return { ...json, results: newData, count: newData.length, next_url: null }
         } else {
-          return newData;
+          // just return the response
+          return json;
         }
 
       } catch (e) {


### PR DESCRIPTION
Release v7.3.0 unintentionally introduced a breaking change to the response format, removing the results attribute and returning the results array in its place. This fixes that, as well as adding tests to ensure the response has the intended shape.