### PR TITLE
Fix/ws examples

### DIFF
--- a/examples/websocket/polygon-business.js
+++ b/examples/websocket/polygon-business.js
@@ -1,8 +1,8 @@
 import { websocketClient } from "@polygon.io/client-js";
 
 /* 
-		This example uses polygon client-js library to connect to the polygon stocks for business 
-		websocket to subscribe to the fair market value channel for the ticker AAPL.
+	This example uses polygon client-js library to connect to the polygon stocks for business 
+	websocket to subscribe to the fair market value channel for the ticker AAPL.
 */
 
 // create a websocket client using the polygon client-js library

--- a/examples/websocket/polygon-business.js
+++ b/examples/websocket/polygon-business.js
@@ -1,0 +1,29 @@
+import { websocketClient } from "@polygon.io/client-js";
+
+/* 
+		This example uses polygon client-js library to connect to the polygon stocks for business 
+		websocket to subscribe to the fair market value channel for the ticker AAPL.
+*/
+
+// create a websocket client using the polygon client-js library
+const ws  = websocketClient('API KEY', 'wss://business.polygon.io').stocks();
+
+// register a handler to log errors
+ws.onerror = (err) => console.log('Failed to connect', err);
+
+// register a handler to log info if websocket closes
+ws.onclose = (code, reason) => console.log('Connection closed', code, reason);
+
+// register a handler when messages are received
+ws.onmessage = (msg) => {
+	// parse the data from the message
+	const parsedMessage = JSON.parse(msg.data);
+
+	// wait until the message saying authentication was successful, then subscribe to a channel
+	if (parsedMessage[0].ev === 'status' && parsedMessage[0].status === 'auth_success') {
+		console.log('Subscribing to Fair Market Value channel for ticker AAPL');
+		ws.send(JSON.stringify({"action":"subscribe", "params":"FMV.AAPL"}));
+	}
+
+	console.log('Message received:', parsedMessage);
+}

--- a/examples/websocket/polygon-client-library.js
+++ b/examples/websocket/polygon-client-library.js
@@ -1,6 +1,6 @@
 /* 
-		This example uses polygon client-js library to connect to the  delayed stocks polygon 
-		websocket to subscribe to minute ohlc values for the ticker AAPL.
+	This example uses polygon client-js library to connect to the  delayed stocks polygon 
+	websocket to subscribe to minute ohlc values for the ticker AAPL.
 */
 
 import { websocketClient } from "@polygon.io/client-js";

--- a/examples/websocket/polygon-client-library.js
+++ b/examples/websocket/polygon-client-library.js
@@ -1,0 +1,30 @@
+/* 
+		This example uses polygon client-js library to connect to the  delayed stocks polygon 
+		websocket to subscribe to minute ohlc values for the ticker AAPL.
+*/
+
+import { websocketClient } from "@polygon.io/client-js";
+
+// create a websocket client using the polygon client-js library
+const ws  = websocketClient('API KEY', 'wss://delayed.polygon.io').stocks(); // 15-min delay websocket
+// const ws  = websocketClient('API KEY', 'wss://socket.polygon.io').stocks(); // real-time webscoket
+
+// register a handler to log errors
+ws.onerror = (err) => console.log('Failed to connect', err);
+
+// register a handler to log info if websocket closes
+ws.onclose = (code, reason) => console.log('Connection closed', code, reason);
+
+// register a handler when messages are received
+ws.onmessage = (msg) => {
+	// parse the data from the message
+	const parsedMessage = JSON.parse(msg.data);
+
+	// wait until the message saying authentication was successful, then subscribe to a channel
+	if (parsedMessage[0].ev === 'status' && parsedMessage[0].status === 'auth_success') {
+		console.log('Subscribing to the minute aggregates channel for ticker AAPL');
+		ws.send(JSON.stringify({"action":"subscribe", "params":"AM.AAPL"}));
+	}
+
+	console.log('Message received:', parsedMessage);
+}

--- a/examples/websocket/ws-library-advanced.js
+++ b/examples/websocket/ws-library-advanced.js
@@ -7,8 +7,8 @@ const APIKEY = process.env.POLY_API_KEY || 'YOUR_API_KEY'
 
 
 /*
-	This example is similar to the basic example provided, however 
-	in addition it offers reconnection logic, as well as an easier 
+	This example also uses the ws (https://github.com/websockets/ws) library to connect to a websocket, 
+	adding reconnection logic, as well as an easier 
 	way to process each type of messages. We can use the `subscribe`
 	method at any time to subscribe to more channels..
  */

--- a/examples/websocket/ws-library-simple.js
+++ b/examples/websocket/ws-library-simple.js
@@ -1,3 +1,8 @@
+/* 
+		This example uses the ws (https://github.com/websockets/ws) library to connect to the delayed stocks polygon 
+		websocket to subscribe to minute ohlc values for the ticker AAPL.
+*/
+
 import WebSocket from 'ws';
 
 const APIKEY = process.env.POLY_API_KEY || 'YOUR_API_KEY'
@@ -16,8 +21,8 @@ ws.on('open', () => {
 	//ws.send(`{"action":"subscribe","params":"C.AUD/USD,C.USD/EUR,C.USD/JPY"}`)
 
 	// aggregates
-	//ws.send(`{"action":"subscribe","params":"AM.*"}`) // min
-	ws.send(`{"action":"subscribe","params":"A.*"}`) // sec
+	ws.send(`{"action":"subscribe","params":"AM.*"}`) // min
+	// ws.send(`{"action":"subscribe","params":"A.*"}`) // sec
 
 	// trades
 	//ws.send(`{"action":"subscribe","params":"T.*"}`)

--- a/examples/websocket/ws-library-simple.js
+++ b/examples/websocket/ws-library-simple.js
@@ -1,6 +1,6 @@
 /* 
-		This example uses the ws (https://github.com/websockets/ws) library to connect to the delayed stocks polygon 
-		websocket to subscribe to minute ohlc values for the ticker AAPL.
+	This example uses the ws (https://github.com/websockets/ws) library to connect to the delayed stocks polygon 
+	websocket to subscribe to minute ohlc values for the ticker AAPL.
 */
 
 import WebSocket from 'ws';


### PR DESCRIPTION
Add examples for using websockets with the client library for individuals and businesses. 
Clarify through naming and comments the websocket examples that use outside libraries instead of the client library.  I think it's a bit confusing to have these in here at all, but until we revisit making the client a little better for websockets, I think these could be useful for people.