### PR TITLE
Add CGI to IIndicesGroups

### DIFF
--- a/src/rest/reference/marketStatus.ts
+++ b/src/rest/reference/marketStatus.ts
@@ -5,6 +5,7 @@ import { IGet, IPolygonQuery, IRequestOptions } from "../transport/request.js";
 export interface IIndicesGroups {
   s_and_p?: string;
   societe_generale?: string;
+  cgi?: string;
   msci?: string;
   ftse_russell?: string;
   mstar?: string;


### PR DESCRIPTION
CBOE recently added the CGI (CBOE Global Indices) feed, and as a result it was added to the Market Status endpoint.