### PR TITLE
fix: missing timeframe `ttm` in stock financials

### DIFF
--- a/src/rest/reference/stockFinancials.ts
+++ b/src/rest/reference/stockFinancials.ts
@@ -62,7 +62,7 @@ export interface IStockFinancialQuery extends IPolygonQuery {
   "period_of_report_date.lte"?: string;
   "period_of_report_date.gt"?: string;
   "period_of_report_date.gte"?: string;
-  timeframe?: "annual" | "quarterly";
+  timeframe?: "annual" | "quarterly" | "ttm";
   included_sources?: "true" | "false";
   order?: "asc" | "desc";
   limit?: number;


### PR DESCRIPTION
As documented here: https://polygon.io/docs/stocks/get_vx_reference_financials

The `timeframe` parameter in stock financials endpoint has three possible values: annual, quarterly, and ttm

But JS client has no support for `ttm` option. This PR fixes it.