### PR TITLE
fix: market status `afterhours` typo

### DIFF
--- a/src/rest/reference/marketStatus.ts
+++ b/src/rest/reference/marketStatus.ts
@@ -16,7 +16,7 @@ export interface IIndicesGroups {
 }
 
 export interface IMarketStatus {
-  afterhours?: boolean;
+  afterHours?: boolean;
   currencies?: {
     fx?: string;
     crypto?: string;


### PR DESCRIPTION
As documented here: https://polygon.io/docs/stocks/get_v1_marketstatus_now

The response has `afterHours` property but JS client has a typo and looks for `afterhours` in the response. Thus, its value is returned as undefined. This PR fixes it.