### PR TITLE
Add Missing Fields for Universal Snapshots

### DIFF
--- a/src/rest/universal/universalSnapshot.ts
+++ b/src/rest/universal/universalSnapshot.ts
@@ -79,6 +79,7 @@ export interface UniversalSnapshotInfo {
   underlying_asset?: UniversalSnapshotUnderlyingAsset;
   value?: number;
   break_even_price?: number;
+  fmv?: number;
 }
 
 export interface IUniversalSnapshotQuery extends IPolygonQuery {

--- a/src/rest/universal/universalSnapshot.ts
+++ b/src/rest/universal/universalSnapshot.ts
@@ -21,8 +21,10 @@ export interface UniversalSnapshotLastQuote {
   timeframe?: string;
   ask?: number;
   ask_size?: number;
+  ask_exchange?: number,
   bid?: number;
   bid_size?: number;
+  bid_exchange?: number;
   midpoint?: number;
   exchange?: number;
 }


### PR DESCRIPTION
First commit Closes #200 
Issue:
The universal snapshot endpoint returns a `last_quote` field, which subsequently should have `ask_exchange` and `bid_exchange` fields for asset classes like Forex. See example api call:
`https://api.polygon.io/v3/snapshot?ticker.any_of=C:USDJPY&limit=1&apiKey=...`

```
{
    "results": [
        {
            "market_status": "open",
            "name": "United States dollar - Japanese yen",
            "ticker": "C:USDJPY",
            "type": "fx",
            "session": {
                "change": -1.35,
                "change_percent": -0.929,
                "close": 144.004,
                "high": 145.551,
                "low": 143.994,
                "open": 145.361,
                "volume": 172978,
                "previous_close": 145.36
            },
            "last_quote": {
                "last_updated": 1725469522000000000,
                "timeframe": "REAL-TIME",
                "ask": 144.02,
                "ask_exchange": 48,
                "bid": 144.01,
                "bid_exchange": 48,
                "exchange": 48
            }
        }
    ]
}
```

Second commit closes #191 
Using an API key that has FMV we can see the `fmv` field in the results, at the very bottom
```
{
    "results": [
        {
            "market_status": "open",
            "name": "SPDR S&P 500 ETF Trust",
            "ticker": "SPY",
            "type": "stocks",
            "session": {
                "change": 0.6,
                "change_percent": 0.11,
                "early_trading_change": 0,
                "early_trading_change_percent": 0,
                "close": 546.853,
                "high": 548.627,
                "low": 543.482,
                "open": 548.36,
                "volume": 20235687,
                "previous_close": 546.41,
                "price": 547.01
            },
            "last_quote": {
                "last_updated": 1725990045418145300,
                "timeframe": "REAL-TIME",
                "ask": 547.03,
                "ask_size": 1,
                "ask_exchange": 15,
                "bid": 546.99,
                "bid_size": 1,
                "bid_exchange": 15
            },
            "last_trade": {
                "last_updated": 1725990044387059500,
                "timeframe": "REAL-TIME",
                "id": "56385696856377",
                "price": 547.01,
                "size": 10,
                "exchange": 15,
                "conditions": [
                    37
                ]
            },
            "fmv": 546.987
        }
    ],
}
```