### PR TITLE
Update tickers.ts

### DIFF
--- a/src/rest/reference/tickers.ts
+++ b/src/rest/reference/tickers.ts
@@ -16,7 +16,7 @@ export type TickerTypes =
   | "INDEX"
   | "ETF"
   | "ETN";
-export type MarketType = "stocks" | "crypto" | "fx";
+export type MarketType = "stocks" | "crypto" | "fx" | "otc" | "indices";
 export type Order = "asc" | "desc";
 
 export interface ITickersQuery extends IPolygonQuery {
@@ -42,7 +42,7 @@ export interface ITickersQuery extends IPolygonQuery {
 export interface ITickersResults {
   ticker: string;
   name: string;
-  market: string;
+  market: MarketType;
   locale: string;
   primary_exchange: string;
   type: string;


### PR DESCRIPTION
fix types to match  api docs
![image](https://github.com/user-attachments/assets/335a22e9-1740-4580-807c-6869ca70386b)


`results[].market` ->
![image](https://github.com/user-attachments/assets/a145f9c7-6a6b-4b8e-b519-010e5c787032)
