### PR TITLE
Remove futures hack and add quotes to example object params

### DIFF
--- a/scripts/generate-examples-with-tokens.js
+++ b/scripts/generate-examples-with-tokens.js
@@ -85,7 +85,10 @@ Object.entries(spec.paths).forEach(([route, methods]) => {
 
         const paramObjectStr = JSON.stringify(merged, null, 2)
           .replace(/^/gm, '      ')
-          .replace(/"([^"]+)":/g, '$1:'); // Remove quotes from keys
+          .replace(/"([^"]+)":/g, (match, key) => {
+            // Only remove quotes from keys that are valid JS identifiers
+            return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key) ? `${key}:` : `"${key}":`;
+          });
 
         callLine = `    const response = await rest.${funcName}(\n${paramObjectStr}\n    );`;
       }

--- a/scripts/pull_spec.js
+++ b/scripts/pull_spec.js
@@ -31,9 +31,6 @@ const main = async () => {
       // Skip paths marked as drafts
       if (pathObj["x-polygon-draft"]) continue;
 
-      // Skip incomplete futures endpoints
-      if (path.startsWith('/futures/vX/')) continue;
-
       // Since all endpoints use GET, process the 'get' method
       const operation = pathObj.get;
       const key = `${path}+${operation.operationId}`; // e.g., "/fed/vX/treasury-yields+TreasuryYields"


### PR DESCRIPTION
Two changes:

- Removed futures skip step since the spec is fixed
- Updated example generation to add quotes around param objects

Tested locally.