### PR TITLE
[DVX-889] isolate axios instance to prevent global interceptor side effects

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,17 +15,20 @@ export const restClient = (apikey: string, restApiBase?: string, globalFetchOpti
   // Note: This does not include any custom interceptors or configurations
   const config = new Configuration({ apiKey: apikey });
   const SERVICE_BASE_URL = 'https://api.polygon.io'; // Fallback to default if not set
-  axios.interceptors.response.use(async (response) => {
+
+  // Create a new axios instance to avoid global interceptor pollution
+  const axiosInstance = axios.create();
+  axiosInstance.interceptors.response.use(async (response) => {
     if (globalFetchOptions?.pagination && response?.data?.next_url) {
       // If pagination is enabled and has a next_url, auto paginate the results and count
-      const nextResults: any = await axios.get(`${response.data.next_url}&apiKey=${apikey}`);
+      const nextResults: any = await axiosInstance.get(`${response.data.next_url}&apiKey=${apikey}`);
       const { results, count } = nextResults;
       return { ...response.data, results: [...results, ...response.data?.results], ...(response.data?.count && { count: response.data.count + count }) };
     }
     return response?.data
   }
 );
-  return new DefaultApi(config, restApiBase || SERVICE_BASE_URL, axios);
+  return new DefaultApi(config, restApiBase || SERVICE_BASE_URL, axiosInstance);
 }
 
 export const polygonClient = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
refactor: isolate axios instance to prevent global interceptor side effects
- fixes bug in Polygon client library where subsequent calls return `undefined` even though the network request succeeds
  - first fetch works and renders as expected
  - subsequent fetches retrieve data from API successfully (verified in browser network inspector), but API returns `undefined`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://linear.app/mod-labs/issue/DVX-889/dev-fix-bug-w-subsequent-fetches-in-client-js-library
- discovered while testing API w/ demo — [see gist for code example](https://gist.github.com/penelopus/419ecb42fc4673ec21fb0537fa23db74)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally w/ fix
- with this branch, run `npm pack` to generate a *.tgz
- in sample project (using gist referenced above), link to local package w/ `npm install <path_to_tgz>`
- verify initial and subsequent data fetches return expected payload (no `undefined`)