### PR TITLE
[DVX-919] support exchanges for Business futures websockets — v8.2.0 alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "8.1.0",
+  "version": "8.2.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@polygon.io/client-js",
-      "version": "8.1.0",
+      "version": "8.2.0-alpha.0",
       "license": "MIT",
       "workspaces": [
         "./dist/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygon.io/client-js",
-  "version": "8.1.0",
+  "version": "8.2.0-alpha.0",
   "description": "Isomorphic Javascript client for Polygon.io Stocks, Forex, and Crypto APIs",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/websockets/futures/index.ts
+++ b/src/websockets/futures/index.ts
@@ -41,5 +41,6 @@ export interface IQuoteFuturesEvent {
 
 export const getFuturesWebsocket = (
   apiKey: string,
-  apiBase = "wss://socket.polygon.io"
-): websocket.w3cwebsocket => getWsClient(`${apiBase}/futures`, apiKey);
+  apiBase = "wss://socket.polygon.io",
+  exchange?: string
+): websocket.w3cwebsocket => getWsClient(`${apiBase}/futures${exchange ? `/${exchange}` : ""}`, apiKey);

--- a/src/websockets/index.ts
+++ b/src/websockets/index.ts
@@ -24,14 +24,15 @@ export interface IWebsocketClient {
 
 export const websocketClient = (
   apiKey: string,
-  apiBase?: string
+  apiBase?: string,
+  exchange?: string
 ): IWebsocketClient => ({
   crypto: () => getCryptoWebsocket(apiKey, apiBase),
   forex: () => getForexWebsocket(apiKey, apiBase),
   indices: () => getIndicesWebsocket(apiKey, apiBase),
   options: () => getOptionsWebsocket(apiKey, apiBase),
   stocks: () => getStocksWebsocket(apiKey, apiBase),
-  futures: () => getFuturesWebsocket(apiKey, apiBase),
+  futures: () => getFuturesWebsocket(apiKey, apiBase, exchange),
 });
 
 export default websocketClient;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For Business users and futures websocket connections, the exchange is required
- this PR extends support for an optional exchange parameter

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://linear.app/mod-labs/issue/DVX-919/dev-client-js-support-futures-business-connex-add-market-support

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
extended feature support

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally, and tested/verified w/ internal tool using alpha build
