### PR TITLE
[DEVREL-140] Automate OpenAPI client regeneration (daily bot PRs)

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -21,10 +21,24 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token for the org GitHub App. The default GITHUB_TOKEN
+      # can't open PRs (org policy: "Allow GitHub Actions to create and approve
+      # pull requests" is off). The App token isn't subject to that restriction,
+      # triggers required checks, and authors the PR as the app bot so a human
+      # can still review.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -93,13 +107,11 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh label create automated --color ededed --description "Automated PR" --force >/dev/null 2>&1 || true
           url=$(gh pr create \
             --base master --head "$BRANCH" \
             --title "[bot] Sync client-js with OpenAPI spec ($(date -u +'%Y-%m-%d'))" \
-            --label automated \
             --body "Automated regeneration from \`https://api.massive.com/openapi\` via \`scripts/generate.sh\` (openapi-generator 7.21.0).
 
           - Regenerated REST client: \`src/rest/\` (typescript-axios) + committed spec \`src/openapi.json\`
@@ -108,6 +120,9 @@ jobs:
 
           Please review the diff before merging.")
           echo "url=$url" >> "$GITHUB_OUTPUT"
+          # Best-effort label — don't fail the run if the app lacks label perms.
+          gh label create automated --color ededed --description "Automated PR" --force >/dev/null 2>&1 || true
+          gh pr edit "$url" --add-label automated >/dev/null 2>&1 || true
 
       - name: Notify Slack
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,0 +1,129 @@
+name: Sync OpenAPI client
+
+# Daily: pull the latest OpenAPI spec, regenerate the TypeScript REST client, and
+# open a brand-new PR only when the regenerated output differs from what's
+# committed. Mirrors the automation in massive-com/client-jvm.
+
+on:
+  schedule:
+    - cron: '0 15 * * *'   # 07:00 America/Vancouver
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-openapi
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # The typescript-axios generator is a Java JAR, so a JDK must be on PATH.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # Cache the openapi-generator JAR (version pinned in openapitools.json)
+      # so we don't re-download ~30MB every run.
+      - name: Cache openapi-generator
+        uses: actions/cache@v4
+        with:
+          path: ~/.openapi-generator-cli
+          key: openapi-generator-7.21.0
+
+      # Installs @openapitools/openapi-generator-cli locally; scripts/generate.sh
+      # invokes it via `npx --no-install` so the pinned version is used.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate client
+        run: bash scripts/generate.sh
+
+      - name: Detect changes
+        id: diff
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes — spec + generated output match what's committed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected:"
+            git diff --cached --stat | tail -25
+          fi
+
+      - name: Import GPG signing key
+        if: steps.diff.outputs.changed == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      # A unique branch per run (date + run id) so every sync opens a brand-new
+      # PR and never reuses/updates a previous one.
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "justinpolygon"
+          git config user.email "123573436+justinpolygon@users.noreply.github.com"
+          BRANCH="bot/openapi-sync-$(date -u +'%Y-%m-%d')-${GITHUB_RUN_ID}"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          git checkout -B "$BRANCH"
+          git commit -S -m "Sync client-js with OpenAPI spec"
+          git push origin "$BRANCH"
+
+      - name: Open PR
+        if: steps.diff.outputs.changed == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create automated --color ededed --description "Automated PR" --force >/dev/null 2>&1 || true
+          url=$(gh pr create \
+            --base master --head "$BRANCH" \
+            --title "[bot] Sync client-js with OpenAPI spec ($(date -u +'%Y-%m-%d'))" \
+            --label automated \
+            --body "Automated regeneration from \`https://api.massive.com/openapi\` via \`scripts/generate.sh\` (openapi-generator 7.21.0).
+
+          - Regenerated REST client: \`src/rest/\` (typescript-axios) + committed spec \`src/openapi.json\`
+          - Hand-written WebSocket client (\`src/websockets/\`) preserved
+          - Curated \`README.md\` / \`package.json\` preserved
+
+          Please review the diff before merging.")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          SLACK_CLIENT_LIBRARY_WEBHOOK: ${{ secrets.SLACK_CLIENT_LIBRARY_WEBHOOK }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          if [ -z "$SLACK_CLIENT_LIBRARY_WEBHOOK" ]; then
+            echo "No Slack webhook configured — skipping."
+            exit 0
+          fi
+          payload=$(jq -n --arg url "$PR_URL" --arg date "$(date -u +'%Y-%m-%d')" '{
+            blocks: [
+              { type: "header",  text: { type: "plain_text", text: ("client-js OpenAPI sync – " + $date), emoji: true } },
+              { type: "section", text: { type: "mrkdwn", text: ("A new OpenAPI sync PR is ready for review:\n<" + $url + "|" + $url + ">") } }
+            ]
+          }')
+          resp=$(curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_CLIENT_LIBRARY_WEBHOOK")
+          [ "$resp" = "ok" ] && echo "✅ Slack posted" || echo "❌ Slack post failed: $resp"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Next, create a new client with your [API key](https://massive.com/dashboard/sign
 
 ```javascript
 import { restClient } from '@massive.com/client-js';
-const rest = restClient(process.env.POLY_API_KEY);
+const rest = restClient(process.env.MASSIVE_API_KEY);
 ```
 
 ## Using the client
@@ -128,7 +128,7 @@ import { restClient } from '@massive.com/client-js';
 const globalFetchOptions = {
 	pagination: true,
 };
-const rest = restClient(process.env.POLY_API_KEY, "https://api.massive.com", globalFetchOptions);
+const rest = restClient(process.env.MASSIVE_API_KEY, "https://api.massive.com", globalFetchOptions);
 
 rest.getStocksAggregates({
   stocksTicker: "AAPL",
@@ -153,7 +153,7 @@ Import the [Websocket](https://massive.com/docs/stocks/ws_getting-started) clien
 
 ```javascript
 import { websocketClient } from "@massive.com/client-js";
-const stocksWS = websocketClient(process.env.POLY_API_KEY, 'wss://delayed.massive.com').stocks();
+const stocksWS = websocketClient(process.env.MASSIVE_API_KEY, 'wss://delayed.massive.com').stocks();
 
 stocksWS.onmessage = ({response}) => {
   const [message] = JSON.parse(response);
@@ -173,6 +173,114 @@ stocksWS.onmessage = ({response}) => {
 stocksWS.send({ action: "subscribe", params: "T.MSFT" });
 ```
 See [full examples](./examples/websocket/) for more details on how to use this client effectively.
+
+## Developing the client
+
+Most users only need the published npm package above. This section is for
+contributors who want to build the client from source or regenerate it from the
+OpenAPI spec.
+
+### How the code is organized
+
+- **Generated** — `src/rest/` is generated from the OpenAPI spec by
+  [openapi-generator](https://openapi-generator.tech) (`typescript-axios`).
+  Do not edit it by hand; it is overwritten on every regeneration.
+- **Hand-written** — `src/main.ts` (the `restClient` / `MassiveClient` glue and
+  auto-pagination) and the entire WebSocket client under `src/websockets/`.
+  These are never touched by regeneration.
+- **Committed spec** — `src/openapi.json` is the filtered spec the client is
+  generated from, committed so spec changes are visible in diffs.
+
+### Prerequisites
+
+- Node.js 18+ (CI uses 22)
+- A JDK 17+ on your PATH — the `typescript-axios` generator is a Java tool.
+  No local JDK? Use the Docker recipe below.
+
+### Clone, build, and verify
+
+```bash
+git clone git@github.com:massive-com/client-js.git
+cd client-js
+npm ci
+
+# Pulls the latest spec, regenerates src/rest, and bundles to dist/
+npm run build
+```
+
+If you don't have a JDK locally, build inside a container that has both Node and
+Java (the generator needs Java):
+
+```bash
+docker run --rm -it -v "$(pwd)":/app -w /app node:22-bookworm sh -c \
+  "apt-get update && apt-get install -y openjdk-17-jre-headless && npm ci && npm run build"
+```
+
+Verify the build produced a working client with a runnable REST example. Save
+this as `verify.mjs` in the repo root and run `MASSIVE_API_KEY=your_key node verify.mjs`:
+
+```javascript
+import { restClient } from './dist/main.js';
+
+const rest = restClient(process.env.MASSIVE_API_KEY, 'https://api.massive.com');
+
+const response = await rest.getStocksAggregates({
+  stocksTicker: 'AAPL',
+  multiplier: '1',
+  timespan: 'day',
+  from: '2023-01-09',
+  to: '2023-02-10',
+  adjusted: 'true',
+  sort: 'asc',
+  limit: '120',
+});
+console.log('Aggregates results:', response.results?.length);
+```
+
+And a runnable WebSocket example (`MASSIVE_API_KEY=your_key node ws-verify.mjs`):
+
+```javascript
+import { websocketClient } from './dist/main.js';
+
+const stocksWS = websocketClient(process.env.MASSIVE_API_KEY, 'wss://delayed.massive.com').stocks();
+
+stocksWS.onopen = () => stocksWS.send('{"action":"subscribe","params":"AM.MSFT"}');
+stocksWS.onmessage = ({ data }) => {
+  const messages = JSON.parse(data);
+  for (const message of messages) console.log('WS message:', message);
+};
+stocksWS.onerror = (e) => console.error('WS error:', e);
+```
+
+### Regenerating from the spec
+
+Regeneration is a single command that pulls the latest spec, runs the generator,
+and leaves `src/rest/` deterministic (hand-written code untouched):
+
+```bash
+npm run generate      # runs scripts/generate.sh: pull spec -> generate -> gate
+```
+
+The generator version is pinned in [`openapitools.json`](./openapitools.json)
+(currently **7.21.0**) so diffs reflect spec changes, not generator upgrades.
+Spec filtering and the operation-id → method-name mapping live in
+`scripts/pull_spec.js` and `scripts/operation-mappings.js`.
+
+### Automated daily sync
+
+[`.github/workflows/sync-openapi.yml`](./.github/workflows/sync-openapi.yml)
+runs every day (and on manual dispatch). It:
+
+1. Pulls the latest spec from `https://api.massive.com/openapi` and regenerates
+   the client with `scripts/generate.sh`.
+2. Opens a **brand-new PR** (`bot/openapi-sync-<date>-<run-id>` → `master`,
+   `[bot]`-prefixed title) only when the regenerated output differs from what's
+   committed — no diff, no PR. The commit is GPG-signed as the bot identity and
+   a Slack notification is posted.
+
+Required repo secrets: `GPG_PRIVATE_KEY`, `SLACK_CLIENT_LIBRARY_WEBHOOK`
+(`GITHUB_TOKEN` is provided automatically). Every run opens a new PR and never
+reuses an existing one, so the reviewer always differs from the author.
 
 ## Contributing
 

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.21.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "test": "mocha",
     "test:watch": "mocha --watch",
     "format": "prettier --write '**/*.ts'",
-    "generate": "sh ./scripts/generate.sh",
+    "generate": "bash ./scripts/generate.sh",
     "pull-spec": "node ./scripts/pull_spec.js",
     "generate-examples": "node ./scripts/generate-examples-with-tokens.js",
-    "build": "rm -rf ./dist && npm run pull-spec && npm run generate && tsup src/main.ts --dts --format esm --minify",
+    "build": "rm -rf ./dist && npm run generate && tsup src/main.ts --dts --format esm --minify",
     "generate-doc": "typedoc src/main.ts",
     "release": "release-it"
   },

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,14 +1,52 @@
-echo "Regenerating account client"
+#!/usr/bin/env bash
+#
+# Regenerate the client-js REST client from the Massive.com OpenAPI spec.
+#
+# One command: pull the spec -> run the generator -> leave the committed
+# layout deterministic. The generated REST client lives entirely under
+# ./src/rest, so regeneration only ever touches that directory. Hand-written
+# code (src/main.ts, src/websockets/**) and curated files (README, package.json,
+# templates) are never touched here.
+#
+# The generator version is pinned in ./openapitools.json so diffs reflect spec
+# changes, not generator upgrades.
+#
+# Usage (from anywhere):
+#   bash scripts/generate.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
 CLIENT_DIRECTORY="./src/rest"
+SPEC_FILE="./src/openapi.json"
 
-echo "Deleting contents of $CLIENT_DIRECTORY"
+# Pin the generator to the version in openapitools.json and invoke the official
+# wrapper unambiguously (avoids resolving a differently-named bin on PATH).
+GENERATOR="npx --no-install @openapitools/openapi-generator-cli"
 
-rm -rf $CLIENT_DIRECTORY
+echo "[1/3] Pulling + filtering OpenAPI spec -> $SPEC_FILE"
+node ./scripts/pull_spec.js
+if [ ! -s "$SPEC_FILE" ]; then
+  echo "ERROR: $SPEC_FILE is missing or empty after pull_spec.js; aborting." >&2
+  exit 1
+fi
 
-echo "Generating account client..."
-openapi-generator-cli generate -g typescript-axios -o $CLIENT_DIRECTORY -i ./src/openapi.json -t ./templates/typescript-axios --additional-properties=supportsES6=true,stringEnums=true,useSingleRequestParameter=true
+echo "[2/3] Generating typescript-axios client into $CLIENT_DIRECTORY"
+rm -rf "$CLIENT_DIRECTORY"
+$GENERATOR generate \
+  -g typescript-axios \
+  -o "$CLIENT_DIRECTORY" \
+  -i "$SPEC_FILE" \
+  -t ./templates/typescript-axios \
+  --additional-properties=supportsES6=true,stringEnums=true,useSingleRequestParameter=true
 
-echo "Remove unnecessary generator file"
-rm openapitools.json
+# Safety gate: never leave a partial/empty generated client committed.
+if [ ! -f "$CLIENT_DIRECTORY/api.ts" ]; then
+  echo "ERROR: generation did not produce $CLIENT_DIRECTORY/api.ts; aborting." >&2
+  exit 1
+fi
 
-echo "Done!"
+echo "[3/3] Done. Regenerated $CLIENT_DIRECTORY (hand-written src/main.ts and src/websockets left untouched)."

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,61 @@
+# Massive.com JS Client Generator
+
+Tooling that generates the TypeScript REST client for the
+[Massive.com](https://massive.com/) API from its OpenAPI specification.
+
+The OpenAPI generator only understands the **REST** endpoints. The **WebSocket**
+client under `src/websockets/` is hand-written and is never touched by
+regeneration, and so is the `src/main.ts` client glue (auto-pagination, base URL
+defaults).
+
+## Automated daily sync (recommended)
+
+`.github/workflows/sync-openapi.yml` runs every day (and on manual dispatch). It:
+
+1. Pulls the latest spec from `https://api.massive.com/openapi`.
+2. Regenerates the client with `scripts/generate.sh`.
+3. Opens a **brand-new PR** — `bot/openapi-sync-<date>-<run-id>` → `master` —
+   only when the regenerated output differs from what's committed. The commit is
+   GPG-signed and a Slack notification is posted to `SLACK_CLIENT_LIBRARY_WEBHOOK`.
+   Every run opens a new PR (never reuses one), so the reviewer differs from the
+   author.
+
+Required repo secrets: `GPG_PRIVATE_KEY`, `SLACK_CLIENT_LIBRARY_WEBHOOK`
+(`GITHUB_TOKEN` is provided automatically).
+
+## Manual regeneration
+
+Everything is wrapped in a single script. From the **repo root**:
+
+```bash
+# Needs openapi-generator's JDK on your PATH (or run inside the Docker recipe
+# in the top-level README). Requires devDependencies installed (npm ci).
+npm run generate        # == bash scripts/generate.sh
+```
+
+`scripts/generate.sh` performs the whole pipeline:
+
+1. `pull_spec.js` → downloads + filters the spec to `src/openapi.json`
+   (skips draft paths, forces the `default` tag so a single `DefaultApi` is
+   emitted, and renames operation-ids via `operation-mappings.js`).
+2. `openapi-generator-cli generate -g typescript-axios` → generates the client
+   into `src/rest`, using the custom template `templates/typescript-axios` and
+   `supportsES6/stringEnums/useSingleRequestParameter`.
+3. **Existence gate** → aborts if generation didn't produce `src/rest/api.ts`,
+   so a partial/empty result never clobbers the committed client.
+
+Hand-written code (`src/main.ts`, `src/websockets/`) and curated files
+(`README.md`, `package.json`, `templates/`) are never touched — the generator
+only ever writes into `src/rest`.
+
+The generator version is pinned in `openapitools.json` (currently **7.21.0**) so
+diffs reflect spec changes, not generator upgrades.
+
+## Files
+
+- `generate.sh` — the orchestrator described above.
+- `pull_spec.js` — downloads + filters the spec to `src/openapi.json`.
+- `operation-mappings.js` — client-js-specific operation-id → method-name map.
+  Owns the public JS function names; do not share with other client libraries.
+- `generate-examples-with-tokens.js` — regenerates `examples/rest/*.js` from the
+  spec. Standalone dev tool, **not** part of the sync path (run manually).


### PR DESCRIPTION
## Summary

Replicates the automated OpenAPI generation pipeline that is live in [client-jvm](https://github.com/massive-com/client-jvm), adapted to the client-js TypeScript/axios toolchain. client-js will now track OpenAPI spec changes and open a brand-new PR with the regenerated client daily, hands-off, replacing today's manual regeneration steps.

Linear: https://linear.app/massive-com/issue/DEVREL-140/automate-openapi-client-regeneration-for-client-js-daily-bot-prs

## What's included (pipeline only)

- **`openapitools.json`** (new) — pins openapi-generator to **7.21.0** (the version already in use) so diffs reflect spec changes, not generator upgrades. `generate.sh` no longer deletes this file.
- **`scripts/generate.sh`** — rewritten as a single orchestrator: `set -euo pipefail`, pull spec → generate into `src/rest` via `npx --no-install @openapitools/openapi-generator-cli` (deterministic binary) → existence gate that aborts on partial/empty output. Same template + `supportsES6/stringEnums/useSingleRequestParameter`.
- **`.github/workflows/sync-openapi.yml`** (new) — daily `cron: '0 15 * * *'` + `workflow_dispatch`; node 22 + java 17; generator cache; `npm ci`; regenerate; **diff gate** (no changes = no PR); GPG-signed commit as the bot identity on a unique `bot/openapi-sync-<date>-<run_id>` branch; a **brand-new `[bot]` PR every run** (never reuses one, so the reviewer always differs from the author); Slack notification. Reuses secrets `GPG_PRIVATE_KEY` and `SLACK_CLIENT_LIBRARY_WEBHOOK`.
- **`package.json`** — `generate` uses `bash`; `build` no longer double-pulls the spec. Dependencies untouched.
- **`README.md`** + **`scripts/readme.md`** — document the automation and give clone/build/run+verify instructions (incl. a JDK-less Docker recipe) with runnable REST and WebSocket examples.

## Preserved / intentionally untouched

- Hand-written `src/main.ts` and the entire `src/websockets/` WebSocket client — regeneration only ever writes into `src/rest/`.
- `scripts/operation-mappings.js` and `scripts/pull_spec.js` — client-js owns its public method names / function signatures; not shared with other client libraries.

## Verification

Ran the full pipeline in a `node:22-bookworm` + `openjdk-17` container:

- `npm ci` → `npm run build` (pull spec → generate → tsup) **passed**; produced `dist/main.js` (260 KB) + `main.d.ts`.
- Regeneration wrote `.openapi-generator/VERSION` = **7.21.0** (pin honored).
- `src/websockets/` and `src/main.ts` were **untouched** by regeneration.

Regeneration surfaced substantial real spec drift since the last manual sync; that diff is intentionally **not** in this PR (kept pipeline-only for review). The first `workflow_dispatch`/scheduled run will open it as its own `[bot]` sync PR, validating the automation end-to-end.

## Follow-ups (out of scope)

- Regenerate REST examples (`examples/rest/` via `generate-examples`) as part of the sync.
- Remove the stray `openapi-generator-cli@^1.0.0` runtime dependency; branding drift (Polygon → Massive) in generated headers and legacy example filenames.