### PR TITLE
[MASS-1219] Use GitHub App identity for OpenAPI sync commits

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -82,26 +82,25 @@ jobs:
             git diff --cached --stat | tail -25
           fi
 
-      - name: Import GPG signing key
-        if: steps.diff.outputs.changed == 'true'
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
       # A unique branch per run (date + run id) so every sync opens a brand-new
       # PR and never reuses/updates a previous one.
-      - name: Commit and push
+      - name: Create sync branch
         if: steps.diff.outputs.changed == 'true'
         run: |
-          git config user.name "justinpolygon"
-          git config user.email "123573436+justinpolygon@users.noreply.github.com"
           BRANCH="bot/openapi-sync-$(date -u +'%Y-%m-%d')-${GITHUB_RUN_ID}"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           git checkout -B "$BRANCH"
-          git commit -S -m "Sync client-js with OpenAPI spec"
-          git push origin "$BRANCH"
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        uses: iarekylew00t/verified-bot-commit@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          message: "Sync client-js with OpenAPI spec"
+          ref: ${{ env.BRANCH }}
+          files: |
+            src/
+            scripts/
 
       - name: Open PR
         if: steps.diff.outputs.changed == 'true'

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -16,11 +16,11 @@ defaults).
 2. Regenerates the client with `scripts/generate.sh`.
 3. Opens a **brand-new PR** — `bot/openapi-sync-<date>-<run-id>` → `master` —
    only when the regenerated output differs from what's committed. The commit is
-   GPG-signed and a Slack notification is posted to `SLACK_CLIENT_LIBRARY_WEBHOOK`.
-   Every run opens a new PR (never reuses one), so the reviewer differs from the
-   author.
+   authored by the GitHub App's bot identity and a Slack notification is posted
+   to `SLACK_CLIENT_LIBRARY_WEBHOOK`. Every run opens a new PR (never reuses
+   one), so the reviewer differs from the author.
 
-Required repo secrets: `GPG_PRIVATE_KEY`, `SLACK_CLIENT_LIBRARY_WEBHOOK`
+Required repo secrets: `SLACK_CLIENT_LIBRARY_WEBHOOK`
 (`GITHUB_TOKEN` is provided automatically).
 
 ## Manual regeneration


### PR DESCRIPTION
The OpenAPI sync workflow was using justinpolygon's personal identity and a GPG key to sign commits. This switches to the verified-bot-commit action which creates commits through the Git Data API using the GitHub App token. Commits are automatically marked as verified by GitHub and authored by the GitHub App without needing a separate GPG key.

The `GPG_PRIVATE_KEY` secret is no longer needed by this workflow.